### PR TITLE
fix: announcement hidden by docs nav on mobile

### DIFF
--- a/src/components/Announcements/index.module.scss
+++ b/src/components/Announcements/index.module.scss
@@ -16,20 +16,25 @@
   }
 }
 
+.onDocsPage {
+  @include mid-break {
+    margin-bottom: calc(var(--base) * 3);
+  }
+}
+
 .announcement {
   position: relative;
   display: flex;
   gap: var(--base);
   pointer-events: all;
   margin: var(--spacer);
-  padding: 
-    var(--base) 
-    calc((var(--gutter-h) / 2) - var(--spacer));
+  padding:
+    var(--base) calc((var(--gutter-h) / 2) - var(--spacer));
   transition: color 300ms ease;
   border-bottom: 1px solid var(--announcement-text-color);
   color: var(--announcement-text-color);
   background-color: transparent;
-  
+
   &:after {
     content: '';
     position: absolute;

--- a/src/components/Announcements/index.tsx
+++ b/src/components/Announcements/index.tsx
@@ -5,6 +5,7 @@ import { RichText } from '@components/RichText'
 import { ArrowIcon } from '@root/icons/ArrowIcon'
 import { CloseIcon } from '@root/graphics/CloseIcon'
 import { useCookies } from 'react-cookie'
+import { usePathname } from 'next/navigation'
 import type { Announcement } from '../../payload-types'
 
 import classes from './index.module.scss'
@@ -12,11 +13,17 @@ import classes from './index.module.scss'
 export const Announcements: React.FC<{ announcements: Announcement[] }> = ({ announcements }) => {
   const [closeAnnouncement, setCloseAnnouncement] = React.useState(false)
   const [cookies, setCookie] = useCookies()
+  const pathname = usePathname()
+  const onDocsPage = pathname.startsWith('/docs')
 
   const showAnnouncement = !closeAnnouncement && !cookies.dismissAnnouncement
 
   return (
-    <div className={classes.announcementWrap}>
+    <div
+      className={[classes.announcementWrap, onDocsPage && classes.onDocsPage]
+        .filter(Boolean)
+        .join(' ')}
+    >
       {showAnnouncement &&
         announcements.map(announcement => {
           const { content } = announcement


### PR DESCRIPTION
New announcement banner was covered by docs menu on mobile.

Before:
<img width="490" alt="Screen Shot 2023-03-06 at 6 07 25 PM" src="https://user-images.githubusercontent.com/67977755/223194125-5daf3243-49c7-45ac-8eb0-cfde67b6c5d4.png">

After:
<img width="484" alt="Screen Shot 2023-03-06 at 6 06 23 PM" src="https://user-images.githubusercontent.com/67977755/223194034-9dec142d-5708-412c-bca2-fcf541d51b47.png">
