### PR TITLE
fix: refreshes payment intent when switching teams without existing payment methods

### DIFF
--- a/src/app/new/(checkout)/useDeploy.tsx
+++ b/src/app/new/(checkout)/useDeploy.tsx
@@ -46,11 +46,11 @@ export const useDeploy = (args: {
 
     const stripePayment = await stripe.confirmCardPayment(clientSecret, {
       payment_method:
-        paymentMethod !== 'new-card'
-          ? paymentMethod
-          : {
+        !paymentMethod || paymentMethod.startsWith('new-card')
+          ? {
               card: elements.getElement(StripeCardElement) as StripeCardElementType,
-            },
+            }
+          : paymentMethod,
     })
 
     if (stripePayment.error) {

--- a/src/components/CreditCardSelector/index.tsx
+++ b/src/components/CreditCardSelector/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { v4 as uuid } from 'uuid'
 
 import { CircleIconButton } from '@components/CircleIconButton'
 import { CreditCardElement } from '@components/CreditCardElement'
@@ -14,21 +15,30 @@ export const CreditCardSelector: React.FC<{
   onChange?: (method?: string) => void // eslint-disable-line no-unused-vars
 }> = props => {
   const { onChange, initialValue, team } = props
-  const [internalState, setInternalState] = React.useState(initialValue)
+  const newCardID = React.useRef<string>(`new-card-${uuid()}`)
+  const [internalState, setInternalState] = React.useState(initialValue || newCardID.current)
   const [showNewCard, setShowNewCard] = React.useState(false)
 
   const { result: paymentMethods, error } = useGetPaymentMethods({ team })
 
+  // update the internal state when the payment methods change
+  // preselect the first card if there is only one
+  // generate a unique id for the new card, prefixed with `new-card`
+  // this will allow us to differentiate from a saved card in the checkout process
   useEffect(() => {
-    setShowNewCard(!paymentMethods?.filter(paymentMethod => paymentMethod.id !== 'new-card').length)
-    setInternalState(paymentMethods?.[0]?.id || 'new-card')
-  }, [paymentMethods])
+    const firstCard = paymentMethods?.[0]?.id
+    newCardID.current = `new-card-${uuid()}`
+    setShowNewCard(!firstCard)
+    setInternalState(firstCard || newCardID.current)
+  }, [paymentMethods, newCardID])
 
   useEffect(() => {
     if (typeof onChange === 'function') {
       onChange(internalState)
     }
   }, [onChange, internalState])
+
+  const isNewCard = internalState === newCardID.current
 
   return (
     <div className={classes.creditCardSelector}>
@@ -47,26 +57,26 @@ export const CreditCardSelector: React.FC<{
         ))}
         {showNewCard && (
           <LargeRadio
-            value="new-card"
-            checked={internalState === 'new-card'}
+            value={newCardID}
+            checked={isNewCard}
             onChange={setInternalState}
             label={<CreditCardElement />}
             name="card"
-            id="new-card"
+            id={newCardID.current}
           />
         )}
       </div>
-      {paymentMethods?.filter(paymentMethod => paymentMethod.id !== 'new-card').length > 0 && (
-        <div className={classes.addNew}>
-          <CircleIconButton
-            onClick={() => {
-              setShowNewCard(!showNewCard)
-              setInternalState(showNewCard ? paymentMethods?.[0]?.id || 'new-card' : 'new-card')
-            }}
-            label={showNewCard ? 'Cancel new card' : 'Add new card'}
-          />
-        </div>
-      )}
+      <div className={classes.addNew}>
+        <CircleIconButton
+          onClick={() => {
+            setShowNewCard(!showNewCard)
+            setInternalState(
+              showNewCard ? paymentMethods?.[0]?.id || newCardID.current : newCardID.current,
+            )
+          }}
+          label={showNewCard ? 'Cancel new card' : 'Add new card'}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The `new-card` id was preventing the new payment intents from being made when switching between two teams without existing payment methods. This is because the value `new-card` as useEffect dependency was never new. The fix is to generate uuids for new cards, specifically when changing teams. This will force the effect to run and a new payement intent to be made.