### PR TITLE
fix: subscription creation

### DIFF
--- a/src/app/new/(checkout)/Checkout.tsx
+++ b/src/app/new/(checkout)/Checkout.tsx
@@ -33,8 +33,8 @@ import { useGetProject } from '@root/utilities/use-cloud-api'
 import { useGitAuthRedirect } from '../authorize/useGitAuthRedirect'
 import { EnvVars } from './EnvVars'
 import { checkoutReducer, CheckoutState } from './reducer'
+import { useCreateSubscription } from './useCreateSubscription'
 import { useDeploy } from './useDeploy'
-import { usePaymentIntent } from './usePaymentIntent'
 
 import classes from './Checkout.module.scss'
 
@@ -115,7 +115,7 @@ const Checkout: React.FC<{
     { value: selectedInstall, loading: installsLoading, error: installsError },
   ] = useInstallationSelector({ initialInstallID: project?.installID })
 
-  const { paymentIntent, error: paymentIntentError } = usePaymentIntent({
+  const { paymentIntent, error: paymentIntentError } = useCreateSubscription({
     project,
     checkoutState,
   })

--- a/src/app/new/(checkout)/Checkout.tsx
+++ b/src/app/new/(checkout)/Checkout.tsx
@@ -115,11 +115,6 @@ const Checkout: React.FC<{
     { value: selectedInstall, loading: installsLoading, error: installsError },
   ] = useInstallationSelector({ initialInstallID: project?.installID })
 
-  const { paymentIntent, error: paymentIntentError } = useCreateSubscription({
-    project,
-    checkoutState,
-  })
-
   const onDeploy = useCallback(
     (project: Project) => {
       const redirectURL =
@@ -135,10 +130,9 @@ const Checkout: React.FC<{
 
   const { isDeploying, errorDeploying, deploy } = useDeploy({
     onDeploy,
-    projectID: draftProjectID,
+    project,
     checkoutState,
     installID: selectedInstall?.id.toString() || project?.installID,
-    paymentIntent,
   })
 
   const deleteProject = useCallback(async () => {
@@ -183,7 +177,6 @@ const Checkout: React.FC<{
         <div className={classes.errors}>
           {errorDeploying && <p>{errorDeploying}</p>}
           {installsError && <p>{installsError}</p>}
-          {paymentIntentError && <p>{paymentIntentError}</p>}
           {errorDeleting && <p>{errorDeleting}</p>}
         </div>
         {isDeploying && <p className={classes.submitting}>Submitting, one moment...</p>}

--- a/src/app/new/(checkout)/useCreateSubscription.ts
+++ b/src/app/new/(checkout)/useCreateSubscription.ts
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 
 import type { CheckoutState } from '@root/app/new/(checkout)/reducer'
 import type { Project } from '@root/payload-cloud-types'
@@ -13,64 +13,47 @@ export interface PayloadStripeSubscription {
 export const useCreateSubscription = (args: {
   project: Project
   checkoutState: CheckoutState
-}): { error?: string; subscription?: PayloadStripeSubscription } => {
+}): {
+  error?: string
+  createSubscription: () => Promise<PayloadStripeSubscription>
+  subscription: PayloadStripeSubscription | null
+} => {
   const { project, checkoutState } = args
 
-  const [subscription, setSubscription] = useState<PayloadStripeSubscription>()
+  const [subscription, setSubscription] = useState<PayloadStripeSubscription | null>(null)
   const [error, setError] = useState<string | undefined>('')
   const isRequesting = React.useRef<boolean>(false)
-  const prevPaymentMethod = React.useRef<string | undefined>(checkoutState?.paymentMethod)
 
-  useEffect(() => {
+  const createSubscription = useCallback(async (): Promise<PayloadStripeSubscription> => {
     const { paymentMethod, freeTrial, plan, team } = checkoutState
 
-    // only make a payment intent if the payment method has changed
-    // to do this maintain a ref to the previous payment method
-    // also ensure they have a `stripeCustomerID`
-    if (
-      !isRequesting.current &&
-      prevPaymentMethod.current !== checkoutState.paymentMethod &&
-      project?.id &&
-      plan &&
-      paymentMethod &&
-      team?.stripeCustomerID
-    ) {
-      isRequesting.current = true
-      prevPaymentMethod.current = paymentMethod
+    const req = await fetch(`${process.env.NEXT_PUBLIC_CLOUD_CMS_URL}/api/payment-intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        project: {
+          ...project,
+          plan,
+          team,
+        },
+        paymentMethod,
+        freeTrial,
+      }),
+    })
 
-      setError(undefined)
+    const res: PayloadStripeSubscription = await req.json()
 
-      const createSubscription = async (): Promise<void> => {
-        const req = await fetch(`${process.env.NEXT_PUBLIC_CLOUD_CMS_URL}/api/payment-intent`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            project: {
-              ...project,
-              plan,
-              team,
-            },
-            paymentMethod,
-            freeTrial,
-          }),
-        })
-
-        const res: PayloadStripeSubscription = await req.json()
-
-        if (req.ok) {
-          setSubscription(res)
-        } else {
-          setError(res.error)
-        }
-
-        isRequesting.current = false
-      }
-
-      createSubscription()
+    if (req.ok) {
+      setSubscription(res)
+    } else {
+      setError(res.error)
     }
+
+    isRequesting.current = false
+    return res
   }, [project, checkoutState])
 
-  return { error, subscription }
+  return { error, createSubscription, subscription }
 }

--- a/src/app/new/(checkout)/useCreateSubscription.ts
+++ b/src/app/new/(checkout)/useCreateSubscription.ts
@@ -3,20 +3,20 @@ import React, { useEffect, useState } from 'react'
 import type { CheckoutState } from '@root/app/new/(checkout)/reducer'
 import type { Project } from '@root/payload-cloud-types'
 
-export interface PayloadPaymentIntent {
+export interface PayloadStripeSubscription {
   client_secret: string
   paid?: boolean
   subscription?: string
   error?: string
 }
 
-export const usePaymentIntent = (args: {
+export const useCreateSubscription = (args: {
   project: Project
   checkoutState: CheckoutState
-}): { error?: string; paymentIntent?: PayloadPaymentIntent } => {
+}): { error?: string; subscription?: PayloadStripeSubscription } => {
   const { project, checkoutState } = args
 
-  const [paymentIntent, setPaymentIntent] = useState<PayloadPaymentIntent>()
+  const [subscription, setSubscription] = useState<PayloadStripeSubscription>()
   const [error, setError] = useState<string | undefined>('')
   const isRequesting = React.useRef<boolean>(false)
   const prevPaymentMethod = React.useRef<string | undefined>(checkoutState?.paymentMethod)
@@ -40,7 +40,7 @@ export const usePaymentIntent = (args: {
 
       setError(undefined)
 
-      const makePaymentIntent = async (): Promise<void> => {
+      const createSubscription = async (): Promise<void> => {
         const req = await fetch(`${process.env.NEXT_PUBLIC_CLOUD_CMS_URL}/api/payment-intent`, {
           method: 'POST',
           headers: {
@@ -57,10 +57,10 @@ export const usePaymentIntent = (args: {
           }),
         })
 
-        const res: PayloadPaymentIntent = await req.json()
+        const res: PayloadStripeSubscription = await req.json()
 
         if (req.ok) {
-          setPaymentIntent(res)
+          setSubscription(res)
         } else {
           setError(res.error)
         }
@@ -68,9 +68,9 @@ export const usePaymentIntent = (args: {
         isRequesting.current = false
       }
 
-      makePaymentIntent()
+      createSubscription()
     }
   }, [project, checkoutState])
 
-  return { error, paymentIntent }
+  return { error, subscription }
 }

--- a/src/app/new/(checkout)/useDeploy.tsx
+++ b/src/app/new/(checkout)/useDeploy.tsx
@@ -7,12 +7,11 @@ import { PaymentIntent, StripeCardElement as StripeCardElementType } from '@stri
 import { Project } from '@root/payload-cloud-types'
 import { useAuth } from '@root/providers/Auth'
 import { CheckoutState } from './reducer'
-import { PayloadStripeSubscription } from './useCreateSubscription'
+import { PayloadStripeSubscription, useCreateSubscription } from './useCreateSubscription'
 
 export const useDeploy = (args: {
-  projectID?: string
+  project: Project
   checkoutState: CheckoutState
-  paymentIntent?: PayloadStripeSubscription
   installID?: string
   onDeploy?: (project: Project) => void
 }): {
@@ -21,44 +20,56 @@ export const useDeploy = (args: {
   isDeploying: boolean
   deploy: OnSubmit
 } => {
-  const { paymentIntent, checkoutState, installID, projectID, onDeploy } = args
+  const { checkoutState, installID, project, onDeploy } = args
   const { user } = useAuth()
   const [error, setError] = useState<string | null>(null)
   const [isDeploying, setIsDeploying] = useState(false)
   const stripe = useStripe()
   const elements = useElements()
 
-  const makePayment = useCallback(async (): Promise<PaymentIntent | null> => {
-    if (!paymentIntent || !checkoutState || !stripe || !elements) {
-      throw new Error('No payment intent or checkout state')
-    }
+  const { createSubscription } = useCreateSubscription({
+    project,
+    checkoutState,
+  })
 
-    const { paid, client_secret: clientSecret } = paymentIntent
-    const { plan, paymentMethod } = checkoutState
+  const makePayment = useCallback(
+    async (subscription: PayloadStripeSubscription): Promise<PaymentIntent | null> => {
+      if (!subscription) {
+        throw new Error('No subscription')
+      }
 
-    if (paid) {
-      return null
-    }
+      if (!checkoutState || !stripe || !elements) {
+        throw new Error('No payment intent or checkout state')
+      }
 
-    if (!plan || !clientSecret) {
-      throw new Error('No plan selected or client secret')
-    }
+      const { paid, client_secret: clientSecret } = subscription
+      const { plan, paymentMethod } = checkoutState
 
-    const stripePayment = await stripe.confirmCardPayment(clientSecret, {
-      payment_method:
-        paymentMethod !== 'new-card'
-          ? paymentMethod
-          : {
-              card: elements.getElement(StripeCardElement) as StripeCardElementType,
-            },
-    })
+      if (paid) {
+        return null
+      }
 
-    if (stripePayment.error) {
-      throw new Error(stripePayment.error.message)
-    }
+      if (!plan || !clientSecret) {
+        throw new Error('No plan selected or client secret')
+      }
 
-    return stripePayment.paymentIntent
-  }, [paymentIntent, elements, stripe, checkoutState])
+      const stripePayment = await stripe.confirmCardPayment(clientSecret, {
+        payment_method:
+          paymentMethod !== 'new-card'
+            ? paymentMethod
+            : {
+                card: elements.getElement(StripeCardElement) as StripeCardElementType,
+              },
+      })
+
+      if (stripePayment.error) {
+        throw new Error(stripePayment.error.message)
+      }
+
+      return stripePayment.paymentIntent
+    },
+    [elements, stripe, checkoutState],
+  )
 
   const deploy: OnSubmit = useCallback(
     async ({ unflattenedData: formState }) => {
@@ -69,23 +80,20 @@ export const useDeploy = (args: {
           throw new Error(`No installation ID was found for this project.`)
         }
 
-        if (!paymentIntent) {
-          throw new Error(`No payment intent was found for this project.`)
-        }
-
         if (!user) {
           throw new Error(`You must be logged in to deploy a project.`)
         }
 
-        const { subscription } = paymentIntent || {}
-
         setIsDeploying(true)
         setError(null)
 
-        // process the payment
-        await makePayment()
+        // first create the subscription
+        const subscription = await createSubscription()
 
-        // attempt to deploy the project
+        // then make the payment
+        await makePayment(subscription)
+
+        // finally attempt to deploy the project
         const req = await fetch(`${process.env.NEXT_PUBLIC_CLOUD_CMS_URL}/api/deploy`, {
           credentials: 'include',
           method: 'POST',
@@ -94,12 +102,12 @@ export const useDeploy = (args: {
           },
           body: JSON.stringify({
             project: {
-              id: projectID,
+              id: project?.id,
               ...checkoutState,
               ...formState,
               installID,
             },
-            subscription,
+            subscription: subscription?.subscription,
           }),
         })
 
@@ -132,7 +140,7 @@ export const useDeploy = (args: {
         setIsDeploying(false)
       }
     },
-    [user, makePayment, paymentIntent, installID, checkoutState, projectID, onDeploy],
+    [user, makePayment, installID, checkoutState, project, onDeploy, createSubscription],
   )
 
   return {

--- a/src/app/new/(checkout)/useDeploy.tsx
+++ b/src/app/new/(checkout)/useDeploy.tsx
@@ -7,12 +7,12 @@ import { PaymentIntent, StripeCardElement as StripeCardElementType } from '@stri
 import { Project } from '@root/payload-cloud-types'
 import { useAuth } from '@root/providers/Auth'
 import { CheckoutState } from './reducer'
-import { PayloadPaymentIntent } from './usePaymentIntent'
+import { PayloadStripeSubscription } from './useCreateSubscription'
 
 export const useDeploy = (args: {
   projectID?: string
   checkoutState: CheckoutState
-  paymentIntent?: PayloadPaymentIntent
+  paymentIntent?: PayloadStripeSubscription
   installID?: string
   onDeploy?: (project: Project) => void
 }): {


### PR DESCRIPTION
Creates subscriptions only on deploy. Previously we were using a hook to make the payment intent, but this was creating a new subscription each time the checkout page was loaded or the payment methods were changed. This was not a problem pre-trials because the subscriptions were left "incomplete" until a successful payment.