### PR TITLE
fix: add prop for newTab to serialize CMSLink

### DIFF
--- a/src/components/RichText/Serialize/index.tsx
+++ b/src/components/RichText/Serialize/index.tsx
@@ -147,6 +147,7 @@ export const Serialize: SerializeFunction = ({ content, customRenderers }) => {
                 key={i}
                 type={node.linkType === 'internal' ? 'reference' : 'custom'}
                 url={node.url}
+                newTab={node.newTab as boolean | undefined}
                 reference={node.doc as Reference}
               >
                 <Serialize content={node.children} customRenderers={customRenderers} />


### PR DESCRIPTION
May be missing something, but pretty sure the prop for `newTab` is missing from the serializer for CMSLink.

Hope this helps ;-)