### PR TITLE
fix: Allow text selection above JumpList titles

### DIFF
--- a/src/components/Jumplist/index.module.scss
+++ b/src/components/Jumplist/index.module.scss
@@ -1,9 +1,10 @@
 .node {
+  pointer-events: none;
+  
   &:before {
     display: block;
     content: ' ';
     visibility: hidden;
-    pointer-events: none;
     margin-top: calc(var(--base) * -8);
     height: calc(var(--base) * 8);
   }


### PR DESCRIPTION
| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/45725915/232242539-919aeef4-49b1-437c-8fb9-70f06624edf3.mp4" /> | <video src="https://user-images.githubusercontent.com/45725915/232242553-b73466a3-c5d3-4ee9-aa38-3b83a742e9c6.mp4" />  |

Using Chrome on Windows.
Sorry but I didn't had time to run the project locally so I just tested the changes on the live website. You should test it locally to make sure it doesn't break anything.

---

Didn't read the component code, but looks like it's just here to handle link redirections, if this is the case, it would probably be better to use the CSS [`scroll-margin-top` ](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) property.