### PR TITLE
fix: indicator color properly show red on build failure

### DIFF
--- a/src/app/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.tsx
+++ b/src/app/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.tsx
@@ -92,6 +92,7 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
   const hasBuildLog = deployment?.deploymentStatus
     ? buildLogStates.includes(deployment.deploymentStatus)
     : false
+
   useWebSocket({
     url: hasBuildLog
       ? `${process.env.NEXT_PUBLIC_CLOUD_CMS_URL}/api/deployments/${deployment.id}/logs?logType=BUILD`.replace(
@@ -132,7 +133,7 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
     }
 
     // automatically switch to deploy logs if both are available
-    if (hasBuildLog && hasDeployLog) {
+    if (hasBuildLog && hasDeployLog && deployment?.deploymentStatus !== 'ERROR') {
       setActiveTab('deploy')
     }
 
@@ -163,11 +164,7 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
                       className={[activeTab !== 'build' ? classes.inactiveIndicator : '']
                         .filter(Boolean)
                         .join(' ')}
-                      status={
-                        hasDeployLog || deployment.deploymentStatus !== 'ERROR'
-                          ? 'success'
-                          : 'error'
-                      }
+                      status={deployment.deploymentStatus === 'ERROR' ? 'error' : 'success'}
                       spinner={deployment.deploymentStatus === 'BUILDING'}
                     />
                     Build Logs
@@ -179,14 +176,15 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
                 },
               },
             hasDeployLog &&
-              deployLogs && {
+              deployLogs &&
+              deployment?.deploymentStatus !== 'ERROR' && {
                 label: (
                   <div className={classes.tabLabel}>
                     <Indicator
                       className={[activeTab !== 'deploy' ? classes.inactiveIndicator : '']
                         .filter(Boolean)
                         .join(' ')}
-                      status={deployment.deploymentStatus !== 'ERROR' ? 'success' : 'error'}
+                      status={'success'}
                       spinner={deployment.deploymentStatus === 'DEPLOYING'}
                     />
                     Deploy Logs

--- a/src/app/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.tsx
+++ b/src/app/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.tsx
@@ -164,8 +164,8 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
                       className={[activeTab !== 'build' ? classes.inactiveIndicator : '']
                         .filter(Boolean)
                         .join(' ')}
-                      status={deployment.deploymentStatus === 'ERROR' ? 'error' : 'success'}
-                      spinner={deployment.deploymentStatus === 'BUILDING'}
+                      status={deployment.buildStepStatus === 'ERROR' ? 'error' : 'success'}
+                      spinner={deployment.buildStepStatus === 'RUNNING'}
                     />
                     Build Logs
                   </div>
@@ -177,15 +177,15 @@ export const DeploymentLogs: React.FC<Props> = ({ deployment, setBuilt, setDeplo
               },
             hasDeployLog &&
               deployLogs &&
-              deployment?.deploymentStatus !== 'ERROR' && {
+              deployment.buildStepStatus !== 'ERROR' && {
                 label: (
                   <div className={classes.tabLabel}>
                     <Indicator
                       className={[activeTab !== 'deploy' ? classes.inactiveIndicator : '']
                         .filter(Boolean)
                         .join(' ')}
-                      status={'success'}
-                      spinner={deployment.deploymentStatus === 'DEPLOYING'}
+                      status={deployment.deployStepStatus === 'ERROR' ? 'error' : 'success'}
+                      spinner={deployment.deployStepStatus === 'RUNNING'}
                     />
                     Deploy Logs
                   </div>

--- a/src/payload-cloud-types.ts
+++ b/src/payload-cloud-types.ts
@@ -234,6 +234,8 @@ export interface Deployment {
     | 'SUPERSEDED'
     | 'ERROR'
     | 'CANCELED';
+  deployStepStatus?: 'UNKNOWN' | 'PENDING' | 'RUNNING' | 'ERROR' | 'SUCCESS';
+  buildStepStatus?: 'UNKNOWN' | 'PENDING' | 'RUNNING' | 'ERROR' | 'SUCCESS';
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
There were scenarios where a build could fail, but the build logs indicator would still show green.

- Build logs now show red on deploymentStatus of `ERROR`
- Hide deploy logs tab in when deploymentStatus `ERROR`. This was showing with the default log message in build failure states.

Uses new fields introduced in payloadcms/cloud-cms@845f179c1ca0071af13e4be3dcbbf314adadb9b2