### PR TITLE
chore: simplifies input validation functions

### DIFF
--- a/src/app/cloud/[team-slug]/[project-slug]/(tabs)/settings/(build-settings)/client_page.tsx
+++ b/src/app/cloud/[team-slug]/[project-slug]/(tabs)/settings/(build-settings)/client_page.tsx
@@ -57,24 +57,28 @@ export const ProjectBuildSettingsPage = () => {
           placeholder="Enter a name for your project"
           path="name"
           initialValue={project?.name}
+          required
         />
         <Text
           label="Install Command"
           placeholder="Enter the command to install your project dependencies"
           path="installScript"
           initialValue={project?.installScript}
+          required
         />
         <Text
           label="Build Command"
           placeholder="Enter the command to build your project"
           path="buildScript"
           initialValue={project?.buildScript}
+          required
         />
         <Text
           label="Serve Command"
           placeholder="Enter the command to serve your project"
           path="runScript"
           initialValue={project?.runScript}
+          required
         />
         <BranchSelector
           repositoryFullName={project?.repositoryFullName}

--- a/src/app/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/client_page.tsx
+++ b/src/app/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/client_page.tsx
@@ -47,6 +47,7 @@ const ModalContent: React.FC<ModalContentProps> = ({ confirmSlug }) => {
         onChange={value => {
           setIsDisabled(value.toLowerCase() !== confirmSlug.toLowerCase())
         }}
+        required
       />
 
       <div className={classes.modalActions}>

--- a/src/app/cloud/[team-slug]/settings/client_page.tsx
+++ b/src/app/cloud/[team-slug]/settings/client_page.tsx
@@ -132,7 +132,7 @@ export const TeamSettingsPage = () => {
       >
         <FormSubmissionError />
         <FormProcessing message="Updating team, one moment..." />
-        <Text path="name" label="Team Name" />
+        <Text path="name" label="Team Name" required />
         <UniqueTeamSlug teamID={team?.id} initialValue={team?.slug} />
         <Text path="billingEmail" label="Billing Email" required />
         <Text

--- a/src/app/new/(checkout)/Checkout.tsx
+++ b/src/app/new/(checkout)/Checkout.tsx
@@ -250,8 +250,9 @@ const Checkout: React.FC<{
                         value: 'eu-west',
                       },
                     ]}
+                    required
                   />
-                  <Text label="Project name" path="name" initialValue={project?.name} />
+                  <Text label="Project name" path="name" initialValue={project?.name} required />
                   <TeamSelector
                     onChange={handleTeamChange}
                     className={classes.teamSelector}
@@ -262,6 +263,7 @@ const Checkout: React.FC<{
                         ? project?.team?.id
                         : ''
                     }
+                    required
                   />
                   {isClone && (
                     <Fragment>
@@ -283,6 +285,7 @@ const Checkout: React.FC<{
                             value: template.id,
                           })),
                         ]}
+                        required
                       />
                       <UniqueRepoName
                         repositoryOwner={selectedInstall?.account?.login}
@@ -305,16 +308,19 @@ const Checkout: React.FC<{
                     label="Install Command"
                     path="installScript"
                     initialValue={project?.installScript || 'yarn'}
+                    required
                   />
                   <Text
                     label="Build Command"
                     path="buildScript"
                     initialValue={project?.buildScript || 'yarn build'}
+                    required
                   />
                   <Text
                     label="Serve Command"
                     path="runScript"
                     initialValue={project?.runScript || 'yarn serve'}
+                    required
                   />
                   <BranchSelector
                     repositoryFullName={project?.repositoryFullName}

--- a/src/components/BranchSelector/index.tsx
+++ b/src/components/BranchSelector/index.tsx
@@ -81,7 +81,8 @@ export const BranchSelector: React.FC<{
             label: branch,
             value: branch,
           }))}
-          initialValue={initialValue}
+          required
+          initialValue={branches[0]}
         />
       ) : (
         <Text
@@ -89,6 +90,7 @@ export const BranchSelector: React.FC<{
           path="deploymentBranch"
           placeholder="Enter the branch to deploy"
           initialValue={initialValue}
+          required
         />
       )}
     </Fragment>

--- a/src/components/TeamSelector/index.tsx
+++ b/src/components/TeamSelector/index.tsx
@@ -30,8 +30,9 @@ export const TeamSelector: React.FC<{
   allowEmpty?: boolean
   initialValue?: string
   label?: string | false
+  required?: boolean
 }> = props => {
-  const { onChange, value: valueFromProps, className, allowEmpty, initialValue } = props
+  const { onChange, value: valueFromProps, className, allowEmpty, initialValue, required } = props
   const { user } = useAuth()
 
   const teams = user?.teams?.map(({ team }) => team)
@@ -129,6 +130,7 @@ export const TeamSelector: React.FC<{
         components={{
           MenuList: SelectMenuButton,
         }}
+        required={required}
       />
       <TeamDrawer
         onCreate={newTeam => {

--- a/src/forms/Label/index.tsx
+++ b/src/forms/Label/index.tsx
@@ -5,10 +5,10 @@ import { Props } from './types'
 import classes from './index.module.scss'
 
 const LabelOnly: React.FC<Props> = props => {
-  const { htmlFor, required, label } = props
+  const { htmlFor, required, label, className } = props
 
   return (
-    <label htmlFor={htmlFor} className={classes.label}>
+    <label htmlFor={htmlFor} className={[classes.label, className].filter(Boolean).join(' ')}>
       {label}
       {required && <span className={classes.required}>*</span>}
     </label>

--- a/src/forms/fields/Checkbox/index.module.scss
+++ b/src/forms/fields/Checkbox/index.module.scss
@@ -74,7 +74,7 @@
   }
 }
 
-.label {
+.checkbox .label {
   @include body;
   cursor: pointer;
   margin-bottom: 0;

--- a/src/forms/fields/Checkbox/index.module.scss
+++ b/src/forms/fields/Checkbox/index.module.scss
@@ -73,3 +73,10 @@
     }
   }
 }
+
+.label {
+  @include body;
+  cursor: pointer;
+  margin-bottom: 0;
+  color: var(--theme-text);
+}

--- a/src/forms/fields/Checkbox/index.tsx
+++ b/src/forms/fields/Checkbox/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useEffect } from 'react'
+import Label from '@forms/Label'
 
 import { CheckIcon } from '@root/icons/CheckIcon'
 import Error from '../../Error'
@@ -8,20 +9,6 @@ import { FieldProps } from '../types'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
-
-// "You must agree to the terms of service to deploy your project."
-
-const defaultValidate = (value: boolean): string | true => {
-  if (!value) {
-    return 'This field is required.'
-  }
-
-  if (typeof value !== 'boolean') {
-    return 'This field can only be equal to true or false.'
-  }
-
-  return true
-}
 
 export const Checkbox: React.FC<
   FieldProps<boolean> & {
@@ -34,7 +21,7 @@ export const Checkbox: React.FC<
     label,
     onChange: onChangeFromProps,
     initialValue,
-    validate = defaultValidate,
+    validate,
     className,
     checked: checkedFromProps,
     disabled,
@@ -44,7 +31,20 @@ export const Checkbox: React.FC<
   const prevChecked = React.useRef<boolean | undefined | null>(checked)
   const prevContextValue = React.useRef<boolean | undefined | null>(initialValue)
 
-  const validateFunction = React.useCallback(v => validate(v), [validate])
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: boolean): string | true => {
+      if (required && !fieldValue) {
+        return 'This field is required.'
+      }
+
+      if (typeof fieldValue !== 'boolean') {
+        return 'This field can only be equal to true or false.'
+      }
+
+      return true
+    },
+    [required],
+  )
 
   const {
     onChange,
@@ -55,7 +55,7 @@ export const Checkbox: React.FC<
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate: required ? validateFunction : undefined,
+    validate: validate || defaultValidateFunction,
     required,
   })
 
@@ -121,7 +121,7 @@ export const Checkbox: React.FC<
         <span className={classes.input}>
           <CheckIcon className={classes.icon} size="medium" bold />
         </span>
-        <span className={classes.label}>{label}</span>
+        <Label className={classes.label} htmlFor={path} label={label} required={required} />
       </button>
     </div>
   )

--- a/src/forms/fields/Checkbox/index.tsx
+++ b/src/forms/fields/Checkbox/index.tsx
@@ -11,13 +11,13 @@ import classes from './index.module.scss'
 
 // "You must agree to the terms of service to deploy your project."
 
-const defaultValidate = (value: boolean, options = {} as any) => {
-  if ((value && typeof value !== 'boolean') || (options.required && typeof value !== 'boolean')) {
-    return 'This field can only be equal to true or false.'
+const defaultValidate = (value: boolean): string | true => {
+  if (!value) {
+    return 'This field is required.'
   }
 
-  if (options.required && !value) {
-    return 'This field is required.'
+  if (typeof value !== 'boolean') {
+    return 'This field can only be equal to true or false.'
   }
 
   return true
@@ -44,6 +44,8 @@ export const Checkbox: React.FC<
   const prevChecked = React.useRef<boolean | undefined | null>(checked)
   const prevContextValue = React.useRef<boolean | undefined | null>(initialValue)
 
+  const validateFunction = React.useCallback(v => validate(v), [validate])
+
   const {
     onChange,
     value: valueFromContext,
@@ -53,7 +55,7 @@ export const Checkbox: React.FC<
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: required ? validateFunction : undefined,
     required,
   })
 

--- a/src/forms/fields/Number/index.tsx
+++ b/src/forms/fields/Number/index.tsx
@@ -2,30 +2,19 @@
 
 import React from 'react'
 
+import { isNumber } from '@root/utilities/isNumber'
 import Error from '../../Error'
 import Label from '../../Label'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
 
-const defaultValidate: Validate = val => {
-  const stringVal = val as string
-  const isValid = stringVal && stringVal.length > 0
-
-  if (isValid) {
-    return true
-  }
-
-  return 'Please enter a value.'
-}
-
 export const NumberInput: React.FC<FieldProps<number>> = props => {
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     placeholder,
     onChange: onChangeFromProps,
@@ -33,11 +22,27 @@ export const NumberInput: React.FC<FieldProps<number>> = props => {
     initialValue,
   } = props
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: number | string): string | true => {
+      const stringVal = fieldValue as string
+      if (required && (!fieldValue || stringVal.length === 0)) {
+        return 'Please enter a value.'
+      }
+
+      if (fieldValue && !isNumber(fieldValue)) {
+        return 'This field can only be a number.'
+      }
+
+      return true
+    },
+    [required],
+  )
+
   const { onChange, value, showError, errorMessage } = useField<number>({
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/fields/Phone/Input.tsx
+++ b/src/forms/fields/Phone/Input.tsx
@@ -5,29 +5,16 @@ import PhoneInput from 'react-phone-number-input'
 
 import Error from '../../Error'
 import Label from '../../Label'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
-// import 'react-phone-number-input/style.css'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
-
-const defaultValidate: Validate = val => {
-  const stringVal = val as string
-  const isValid = stringVal && stringVal.length > 0
-
-  if (isValid) {
-    return true
-  }
-
-  return 'Please enter a value.'
-}
 
 const Phone: React.FC<FieldProps<string>> = props => {
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     placeholder,
     onChange: onChangeFromProps,
@@ -35,11 +22,23 @@ const Phone: React.FC<FieldProps<string>> = props => {
     initialValue,
   } = props
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: string): string | true => {
+      const stringVal = fieldValue as string
+      if (required && (!fieldValue || stringVal.length === 0)) {
+        return 'Please enter a value.'
+      }
+
+      return true
+    },
+    [required],
+  )
+
   const { onChange, value, showError, errorMessage } = useField<string>({
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/fields/RadioGroup/index.tsx
+++ b/src/forms/fields/RadioGroup/index.tsx
@@ -4,7 +4,6 @@ import React, { useId } from 'react'
 
 import Error from '../../Error'
 import Label from '../../Label'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
 import { useField } from '../useField'
 
@@ -13,14 +12,6 @@ import classes from './index.module.scss'
 export type Option = {
   label: string | React.ReactElement
   value: string
-}
-
-const defaultValidate: Validate = val => {
-  const isValid = Boolean(val)
-
-  if (isValid) return true
-
-  return 'Please make a selection.'
 }
 
 const RadioGroup: React.FC<
@@ -33,7 +24,7 @@ const RadioGroup: React.FC<
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     options,
     onChange: onChangeFromProps,
@@ -45,11 +36,26 @@ const RadioGroup: React.FC<
 
   const id = useId()
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: string): string | true => {
+      if (required && !fieldValue) {
+        return 'Please make a selection.'
+      }
+
+      if (fieldValue && !options.find(option => option && option.value === fieldValue)) {
+        return 'This field has an invalid selection'
+      }
+
+      return true
+    },
+    [required, options],
+  )
+
   const { onChange, value, showError, errorMessage } = useField<string>({
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/fields/Secret/index.tsx
+++ b/src/forms/fields/Secret/index.tsx
@@ -7,22 +7,10 @@ import { CopyToClipboard } from '@components/CopyToClipboard'
 import { Tooltip } from '@components/Tooltip'
 import { EyeIcon } from '@root/icons/EyeIcon'
 import Error from '../../Error'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
-
-const defaultValidate: Validate = val => {
-  const stringVal = val as string
-  const isValid = stringVal && stringVal.length > 0
-
-  if (isValid) {
-    return true
-  }
-
-  return 'Please enter a value.'
-}
 
 type SecretProps = FieldProps<string> & {
   loadSecret: () => Promise<string>
@@ -32,7 +20,7 @@ export const Secret: React.FC<SecretProps> = props => {
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     placeholder,
     onChange: onChangeFromProps,
@@ -45,6 +33,21 @@ export const Secret: React.FC<SecretProps> = props => {
   const [isValueLoaded, setIsValueLoaded] = React.useState(false)
   const [isHidden, setIsHidden] = React.useState(true)
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: boolean): string | true => {
+      if (required && !fieldValue) {
+        return 'Please enter a value.'
+      }
+
+      if (fieldValue && typeof fieldValue !== 'string') {
+        return 'This field can only be a string.'
+      }
+
+      return true
+    },
+    [required],
+  )
+
   const {
     onChange,
     value = '',
@@ -54,7 +57,7 @@ export const Secret: React.FC<SecretProps> = props => {
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/fields/Select/index.tsx
+++ b/src/forms/fields/Select/index.tsx
@@ -6,8 +6,8 @@ import { useTheme } from '@providers/Theme'
 
 import Error from '../../Error'
 import Label from '../../Label'
-import { Validate } from '../../types'
 import { useFormField } from '../../useFormField'
+import { FieldProps } from '../types'
 
 import classes from './index.module.scss'
 
@@ -16,45 +16,21 @@ type Option = {
   value: any
 }
 
-type ValidateOptions = {
-  required?: boolean
+type SelectProps = FieldProps<string> & {
   options: Option[]
-}
-
-const defaultValidate = (value: string, options: Option[]): string | true => {
-  if (!value) {
-    return 'This field is required.'
-  }
-
-  if (!options.find(option => option && option.value === value)) {
-    return 'This field has an invalid selection'
-  }
-
-  return true
-}
-
-export const Select: React.FC<{
-  path?: string
-  required?: boolean
-  label?: string
-  options: Option[]
-  validate?: Validate
-  onChange?: (value: string | string[]) => void // eslint-disable-line no-unused-vars
-  initialValue?: string | string[]
-  className?: string
   isMulti?: boolean
   components?: {
     [key: string]: React.FC<any>
   }
   selectProps?: any
   value?: string | string[]
-  description?: string
-  disabled?: boolean
-}> = props => {
+}
+
+export const Select: React.FC<SelectProps> = props => {
   const {
     path,
     required,
-    validate = defaultValidate,
+    validate,
     label,
     options,
     onChange,
@@ -72,11 +48,24 @@ export const Select: React.FC<{
   const ref = useRef<any>(null)
   const prevValueFromProps = useRef<string | string[] | undefined>(valueFromProps)
 
-  const validateFunction = useCallback(v => validate(v, options), [validate, options])
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: string): string | true => {
+      if (required && !fieldValue) {
+        return 'This field is required.'
+      }
+
+      if (fieldValue && !options.find(option => option && option.value === fieldValue)) {
+        return 'This field has an invalid selection'
+      }
+
+      return true
+    },
+    [options, required],
+  )
 
   const fieldFromContext = useFormField<string | string[]>({
     path,
-    validate: required ? validateFunction : undefined,
+    validate: validate || defaultValidateFunction,
     initialValue: initialValueFromProps,
   })
 

--- a/src/forms/fields/Select/index.tsx
+++ b/src/forms/fields/Select/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import ReactSelect from 'react-select'
 import { useTheme } from '@providers/Theme'
 
@@ -21,19 +21,16 @@ type ValidateOptions = {
   options: Option[]
 }
 
-const defaultValidate = (value: string, options: ValidateOptions): string | true => {
-  if (
-    typeof value === 'string' &&
-    !options.options.find(option => option && option.value === value)
-  ) {
-    return 'This field has an invalid selection'
-  }
-
-  if (options.required && !value) {
+const defaultValidate = (value: string, options: Option[]): string | true => {
+  if (!value) {
     return 'This field is required.'
   }
 
-  return ''
+  if (!options.find(option => option && option.value === value)) {
+    return 'This field has an invalid selection'
+  }
+
+  return true
 }
 
 export const Select: React.FC<{
@@ -75,9 +72,11 @@ export const Select: React.FC<{
   const ref = useRef<any>(null)
   const prevValueFromProps = useRef<string | string[] | undefined>(valueFromProps)
 
+  const validateFunction = useCallback(v => validate(v, options), [validate, options])
+
   const fieldFromContext = useFormField<string | string[]>({
     path,
-    validate: required ? validate : undefined,
+    validate: required ? validateFunction : undefined,
     initialValue: initialValueFromProps,
   })
 

--- a/src/forms/fields/Text/index.tsx
+++ b/src/forms/fields/Text/index.tsx
@@ -7,22 +7,10 @@ import { CopyToClipboard } from '@components/CopyToClipboard'
 import { Tooltip } from '@components/Tooltip'
 import { EyeIcon } from '@root/icons/EyeIcon'
 import Error from '../../Error'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
-
-const defaultValidate: Validate = val => {
-  const stringVal = val as string
-  const isValid = stringVal && stringVal.length > 0
-
-  if (isValid) {
-    return true
-  }
-
-  return 'Please enter a value.'
-}
 
 export const Text: React.FC<
   FieldProps<string> & {
@@ -36,7 +24,7 @@ export const Text: React.FC<
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     placeholder,
     type = 'text',
@@ -62,6 +50,21 @@ export const Text: React.FC<
 
   const [isHidden, setIsHidden] = React.useState(type === 'password')
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: boolean): string | true => {
+      if (required && !fieldValue) {
+        return 'Please enter a value.'
+      }
+
+      if (fieldValue && typeof fieldValue !== 'string') {
+        return 'This field can only be a string.'
+      }
+
+      return true
+    },
+    [required],
+  )
+
   const {
     onChange,
     value: valueFromContext,
@@ -71,7 +74,7 @@ export const Text: React.FC<
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/fields/Textarea/index.tsx
+++ b/src/forms/fields/Textarea/index.tsx
@@ -5,22 +5,10 @@ import React from 'react'
 import { CopyToClipboard } from '@components/CopyToClipboard'
 import Error from '../../Error'
 import Label from '../../Label'
-import { Validate } from '../../types'
 import { FieldProps } from '../types'
 import { useField } from '../useField'
 
 import classes from './index.module.scss'
-
-const defaultValidate: Validate = val => {
-  const stringVal = val as string
-  const isValid = stringVal && stringVal.length > 0
-
-  if (isValid) {
-    return true
-  }
-
-  return 'Please enter a value.'
-}
 
 export const Textarea: React.FC<
   FieldProps<string> & {
@@ -32,7 +20,7 @@ export const Textarea: React.FC<
   const {
     path,
     required = false,
-    validate = defaultValidate,
+    validate,
     label,
     placeholder,
     onChange: onChangeFromProps,
@@ -47,11 +35,26 @@ export const Textarea: React.FC<
     },
   } = props
 
+  const defaultValidateFunction = React.useCallback(
+    (fieldValue: string): string | true => {
+      if (required && !fieldValue) {
+        return 'Please enter a value.'
+      }
+
+      if (fieldValue && typeof fieldValue !== 'string') {
+        return 'This field can only be a string.'
+      }
+
+      return true
+    },
+    [required],
+  )
+
   const { onChange, value, showError, errorMessage } = useField<string>({
     initialValue,
     onChange: onChangeFromProps,
     path,
-    validate,
+    validate: validate || defaultValidateFunction,
     required,
   })
 

--- a/src/forms/types.ts
+++ b/src/forms/types.ts
@@ -1,6 +1,6 @@
 import type React from 'react'
 
-export type Validate = undefined | ((value: unknown, options?: unknown) => boolean | string)
+export type Validate = undefined | ((value: unknown) => boolean | string)
 
 export type Value = any // eslint-disable-line @typescript-eslint/no-explicit-any
 

--- a/src/forms/useFormField/index.tsx
+++ b/src/forms/useFormField/index.tsx
@@ -59,12 +59,7 @@ export const useFormField = <T extends Value>(options): FormField<T> => {
         valid: true,
       }
 
-      const validationResult =
-        typeof validate === 'function'
-          ? await validate(valueToSend, {
-              required,
-            })
-          : true
+      const validationResult = typeof validate === 'function' ? await validate(valueToSend) : true
 
       if (typeof validationResult === 'string' || validationResult === false) {
         fieldToDispatch.errorMessage = validationResult
@@ -75,7 +70,7 @@ export const useFormField = <T extends Value>(options): FormField<T> => {
 
       dispatchFields(fieldToDispatch)
     },
-    [path, dispatchFields, validate, initialValue, required],
+    [path, dispatchFields, validate, initialValue],
   )
 
   // NOTE: 'internalValue' is NOT debounced

--- a/src/utilities/isNumber.ts
+++ b/src/utilities/isNumber.ts
@@ -1,0 +1,3 @@
+export function isNumber(value: unknown): boolean {
+  return !Number.isNaN(Number(value))
+}


### PR DESCRIPTION
Reduces the amount of overhead the useFormField hook needs to know about. Opts for a different approach allowing the value to be used and passed into the callback. The callbacks can then determine what kind of validation they need to perform.