### PR TITLE
feat: paginates github branch selector

### DIFF
--- a/src/components/BranchSelector/reducer.ts
+++ b/src/components/BranchSelector/reducer.ts
@@ -1,0 +1,21 @@
+interface BranchState {
+  branches: string[]
+}
+
+interface BranchAction {
+  type: 'ADD'
+  payload: BranchState['branches']
+}
+
+export const branchReducer = (state: BranchState, action: BranchAction): BranchState => {
+  switch (action.type) {
+    case 'ADD': {
+      return {
+        ...state,
+        branches: [...(state.branches || []), ...(action?.payload || [])],
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/src/forms/fields/Select/index.tsx
+++ b/src/forms/fields/Select/index.tsx
@@ -23,6 +23,7 @@ type SelectProps = FieldProps<string | string[]> & {
   }
   selectProps?: any
   value?: string | string[]
+  onMenuScrollToBottom?: () => void
 }
 
 export const Select: React.FC<SelectProps> = props => {
@@ -41,6 +42,7 @@ export const Select: React.FC<SelectProps> = props => {
     value: valueFromProps, // allow external control
     description,
     disabled,
+    onMenuScrollToBottom,
   } = props
 
   const id = useId()
@@ -205,6 +207,7 @@ export const Select: React.FC<SelectProps> = props => {
         // @ts-expect-error
         selectProps={selectProps}
         isDisabled={disabled}
+        onMenuScrollToBottom={onMenuScrollToBottom}
       />
       {description && <div className={classes.description}>{description}</div>}
     </div>


### PR DESCRIPTION
Fixes a bug in Cloud where repos with more than 30 branches were unable to paginate through to select deeply listed branches.