### PR TITLE
fix: displays only repos with write access in the clone flow

### DIFF
--- a/src/app/new/(checkout)/Checkout.tsx
+++ b/src/app/new/(checkout)/Checkout.tsx
@@ -56,6 +56,7 @@ const Checkout: React.FC<{
   project: Project | null | undefined
 }> = props => {
   const { project } = props
+  const isClone = Boolean(!project?.repositoryID)
 
   const router = useRouter()
   const { templates } = useGlobals()
@@ -101,7 +102,10 @@ const Checkout: React.FC<{
   const [
     InstallationSelector,
     { value: selectedInstall, loading: installsLoading, error: installsError },
-  ] = useInstallationSelector({ initialInstallID: project?.installID })
+  ] = useInstallationSelector({
+    initialInstallID: project?.installID,
+    permissions: isClone ? 'write' : undefined,
+  })
 
   const onDeploy = useCallback(
     (project: Project) => {
@@ -156,8 +160,6 @@ const Checkout: React.FC<{
       setErrorDeleting(`There was an error deleting your project: ${error?.message || 'Unknown'}`)
     }
   }, [project, router])
-
-  const isClone = Boolean(!project?.repositoryID)
 
   return (
     <Form onSubmit={deploy}>

--- a/src/app/new/clone/[template]/CloneTemplate.tsx
+++ b/src/app/new/clone/[template]/CloneTemplate.tsx
@@ -30,7 +30,10 @@ export const CloneTemplate: React.FC<{
   const { user } = useAuth()
   const { template } = props
   const router = useRouter()
-  const [InstallationSelector, { value: selectedInstall }] = useInstallationSelector()
+
+  const [InstallationSelector, { value: selectedInstall }] = useInstallationSelector({
+    permissions: 'write',
+  })
 
   const matchedTeam = user?.teams?.find(
     ({ team }) => typeof team !== 'string' && team?.slug === teamParam,

--- a/src/components/InstallationSelector/index.tsx
+++ b/src/components/InstallationSelector/index.tsx
@@ -175,7 +175,7 @@ export const InstallationSelector: React.FC<InstallationSelectorProps> = props =
   )
 }
 
-type UseInstallationSelectorArgs = {
+type UseInstallationSelectorArgs = Parameters<UseGetInstalls>[0] & {
   initialInstallID?: string
 }
 
@@ -191,9 +191,9 @@ export const useInstallationSelector = (
     description?: string
   },
 ] => {
-  const { initialInstallID } = args
+  const { initialInstallID, permissions } = args
   const [value, setValue] = React.useState<Install | undefined>(undefined)
-  const installsData = useGetInstalls()
+  const installsData = useGetInstalls({ permissions })
   const { error, installs, reload, loading } = installsData
 
   const debouncedLoading = useDebounce(loading, 250)


### PR DESCRIPTION
Previously, if your app installation only had `read` access to the scope, the "clone" flow would still display those to you and ultimately error out on initial project deployment. Now when cloning, we display only scopes with `write` access to the user.