### PR TITLE
chore: redirects doc topics to first doc of topic instead of 404

### DIFF
--- a/src/app/(pages)/docs/[topic]/[doc]/page.tsx
+++ b/src/app/(pages)/docs/[topic]/[doc]/page.tsx
@@ -50,6 +50,7 @@ type Param = {
   topic: string
   doc: string
 }
+
 export async function generateStaticParams() {
   const topics = await getTopics()
 

--- a/src/app/(pages)/docs/[topic]/page.tsx
+++ b/src/app/(pages)/docs/[topic]/page.tsx
@@ -1,0 +1,21 @@
+import { notFound, redirect } from 'next/navigation'
+
+import { getTopics } from '../api'
+
+export default async function DocTopic({ params: { topic: topicSlug } }) {
+  const topics = await getTopics()
+  const topic = topics.find(({ slug }) => slug.toLowerCase() === topicSlug)
+  const firstDocInTopic = topic?.docs[0]?.slug
+
+  if (!topic || !firstDocInTopic) notFound()
+
+  redirect(`/docs/${topicSlug}/${firstDocInTopic}`)
+}
+
+export async function generateStaticParams() {
+  const topics = await getTopics()
+
+  return topics.map(({ slug }) => ({
+    topic: slug.toLowerCase(),
+  }))
+}


### PR DESCRIPTION
`/docs/fields` will now redirect to `/docs/fields/overview` for example, instead of 404 like it currently does.