### PR TITLE
feat: builds RelatedPosts block

### DIFF
--- a/src/app/(pages)/blog/[slug]/AuthorsList/index.module.scss
+++ b/src/app/(pages)/blog/[slug]/AuthorsList/index.module.scss
@@ -14,6 +14,11 @@
 
 .authorLink {
   text-decoration: none;
+
+  &:focus {
+    outline: none;
+    text-decoration: underline;
+  }
 }
 
 .author {

--- a/src/app/(pages)/blog/[slug]/BlogPost/index.module.scss
+++ b/src/app/(pages)/blog/[slug]/BlogPost/index.module.scss
@@ -64,3 +64,7 @@
     margin-bottom: var(--base);
   }
 }
+
+.relatedPosts {
+  margin-top: var(--block-spacing);
+}

--- a/src/app/(pages)/blog/[slug]/BlogPost/index.tsx
+++ b/src/app/(pages)/blog/[slug]/BlogPost/index.tsx
@@ -7,16 +7,20 @@ import { formatDate } from '@utilities/format-date-time'
 
 import { Breadcrumbs } from '@components/Breadcrumbs'
 import { Post } from '@root/payload-types'
-import { Gutter } from '../../../../components/Gutter'
-import { Media } from '../../../../components/Media'
-import { RenderBlocks } from '../../../../components/RenderBlocks'
-import { RichText } from '../../../../components/RichText'
-import { AuthorsList } from './AuthorsList'
+import { Gutter } from '../../../../../components/Gutter'
+import { Media } from '../../../../../components/Media'
+import { RenderBlocks } from '../../../../../components/RenderBlocks'
+import { RichText } from '../../../../../components/RichText'
+import { AuthorsList } from '../AuthorsList'
 
 import classes from './index.module.scss'
 
-export const RenderBlogPost: React.FC<Post> = props => {
-  const { title, publishedOn, image, excerpt, content } = props
+export const BlogPost: React.FC<
+  Post & {
+    relatedPosts?: Post[]
+  }
+> = props => {
+  const { title, publishedOn, image, excerpt, content, relatedPosts } = props
 
   return (
     <React.Fragment>
@@ -65,9 +69,16 @@ export const RenderBlogPost: React.FC<Post> = props => {
           </Cell>
         </Grid>
       </Gutter>
-      <RenderBlocks blocks={content} />
+      <RenderBlocks
+        blocks={[
+          ...(content || []),
+          {
+            blockType: 'relatedPosts',
+            blockName: 'Related Posts',
+            relatedPosts: relatedPosts || [],
+          },
+        ]}
+      />
     </React.Fragment>
   )
 }
-
-export default RenderBlogPost

--- a/src/app/(pages)/blog/[slug]/page.tsx
+++ b/src/app/(pages)/blog/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 
 import { mergeOpenGraph } from '@root/seo/mergeOpenGraph'
 import { fetchBlogPost, fetchPosts } from '../../../../graphql'
-import { RenderBlogPost } from './client_page'
+import { BlogPost } from './BlogPost'
 
 const Post = async ({ params }) => {
   const { slug } = params
@@ -12,7 +12,7 @@ const Post = async ({ params }) => {
 
   if (!blogPost) return notFound()
 
-  return <RenderBlogPost {...blogPost} />
+  return <BlogPost {...blogPost} />
 }
 
 export default Post

--- a/src/blocks/RelatedPosts/index.module.scss
+++ b/src/blocks/RelatedPosts/index.module.scss
@@ -1,0 +1,6 @@
+@use '@scss/common' as *;
+
+.title {
+  margin: 0;
+  margin-bottom: calc(var(--base) * 2);
+}

--- a/src/blocks/RelatedPosts/index.tsx
+++ b/src/blocks/RelatedPosts/index.tsx
@@ -1,0 +1,53 @@
+import { Cell, Grid } from '@faceless-ui/css-grid'
+import { CellProps } from '@faceless-ui/css-grid/dist/Cell'
+
+import { ContentMediaCard } from '@components/cards/ContentMediaCard'
+import { Gutter } from '@components/Gutter'
+import { Post } from '@root/payload-types'
+
+import classes from './index.module.scss'
+
+export type RelatedPostsBlock = {
+  blockType: 'relatedPosts'
+  blockName: string
+  relatedPosts: Post[]
+}
+
+export const RelatedPosts: React.FC<{ relatedPosts: Post[] }> = props => {
+  const { relatedPosts } = props
+
+  if (!relatedPosts || relatedPosts?.length === 0) {
+    return null
+  }
+
+  let cellProps: Partial<CellProps> = {
+    start: 1,
+    cols: 12,
+  }
+
+  if (relatedPosts.length >= 3) {
+    cellProps = {
+      cols: 4,
+      colsM: 6,
+    }
+  }
+
+  return (
+    <Gutter className={classes.relatedPosts}>
+      <h4 className={classes.title}>Related Posts</h4>
+      <Grid>
+        {relatedPosts.map((post, key) => (
+          <Cell key={key} {...cellProps}>
+            <ContentMediaCard
+              title={post.title}
+              description={post?.meta?.description}
+              href={`/blog/${post.slug}`}
+              media={post.image}
+              orientation={relatedPosts.length < 3 ? 'horizontal' : undefined}
+            />
+          </Cell>
+        ))}
+      </Grid>
+    </Gutter>
+  )
+}

--- a/src/components/RenderBlocks/index.tsx
+++ b/src/components/RenderBlocks/index.tsx
@@ -18,6 +18,7 @@ import { LinkGrid } from '@blocks/LinkGrid'
 import { MediaBlock } from '@blocks/MediaBlock'
 import { MediaContent } from '@blocks/MediaContent'
 import { Pricing } from '@blocks/Pricing'
+import { RelatedPosts, RelatedPostsBlock } from '@blocks/RelatedPosts'
 import { ReusableContentBlock } from '@blocks/ReusableContent'
 import { Slider } from '@blocks/Slider'
 import { Steps } from '@blocks/Steps'
@@ -51,10 +52,11 @@ const blockComponents = {
   linkGrid: LinkGrid,
   reusableContentBlock: ReusableContentBlock,
   pricing: Pricing,
+  relatedPosts: RelatedPosts,
 }
 
 type Props = {
-  blocks: (ReusableContent['layout'][0] | ReusableContentBlockType)[]
+  blocks: (ReusableContent['layout'][0] | ReusableContentBlockType | RelatedPostsBlock)[]
   disableOuterSpacing?: true
 }
 

--- a/src/components/cards/ContentMediaCard/index.module.scss
+++ b/src/components/cards/ContentMediaCard/index.module.scss
@@ -1,7 +1,9 @@
 @use '@scss/common' as *;
 
 .blogCard {
-  margin-bottom: calc(var(--base) * 2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--base);
 }
 
 .title {
@@ -16,6 +18,7 @@
     @include h3;
   }
 
+  margin: 0 !important;
   text-decoration: none;
 
   &:hover {
@@ -25,4 +28,36 @@
 
 .media {
   @include shadow-lg;
+}
+
+.mediaLink {
+  flex-shrink: 0;
+  flex-grow: 0;
+}
+
+.content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--base) / 2);
+}
+
+.horizontal {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: calc(var(--base) * 2);
+
+  &:local() {
+    .mediaLink {
+      width: 33.33%;
+    }
+  }
+
+  @include small-break {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--base);
+  }
 }

--- a/src/components/cards/ContentMediaCard/index.tsx
+++ b/src/components/cards/ContentMediaCard/index.tsx
@@ -2,17 +2,21 @@ import * as React from 'react'
 import Link from 'next/link'
 
 import { Media } from '@components/Media'
-import { BlogCardProps } from '../types'
+import { ContentMediaCardProps } from '../types'
 
 import classes from './index.module.scss'
 
-export const ContentMediaCard: React.FC<BlogCardProps> = props => {
-  const { description, href, media, title, className } = props
+export const ContentMediaCard: React.FC<ContentMediaCardProps> = props => {
+  const { description, href, media, title, className, orientation } = props
 
   return (
-    <div className={[classes.blogCard, className && className].filter(Boolean).join(' ')}>
+    <div
+      className={[classes.blogCard, className && className, orientation && classes[orientation]]
+        .filter(Boolean)
+        .join(' ')}
+    >
       {typeof media !== 'string' && (
-        <Link href={href} prefetch={false}>
+        <Link href={href} prefetch={false} className={classes.mediaLink}>
           <Media
             resource={media}
             className={classes.media}
@@ -20,12 +24,12 @@ export const ContentMediaCard: React.FC<BlogCardProps> = props => {
           />
         </Link>
       )}
-
-      <Link href={href} className={classes.title} prefetch={false}>
-        {title}
-      </Link>
-
-      <p>{description}</p>
+      <div className={classes.content}>
+        <Link href={href} className={classes.title} prefetch={false}>
+          {title}
+        </Link>
+        <p>{description}</p>
+      </div>
     </div>
   )
 }

--- a/src/components/cards/types.ts
+++ b/src/components/cards/types.ts
@@ -13,9 +13,10 @@ export interface SquareCardProps extends SharedProps {
   link?: CMSLinkType
 }
 
-export interface BlogCardProps extends SharedProps {
+export interface ContentMediaCardProps extends SharedProps {
   media: Media | string
   href: string
+  orientation?: 'horizontal' | 'vertical'
 }
 
 export interface PricingCardProps extends SharedProps {

--- a/src/graphql/posts.ts
+++ b/src/graphql/posts.ts
@@ -70,6 +70,12 @@ export const POST = `
           ${REUSABLE_CONTENT_BLOCK}
         }
         meta ${META_FIELDS}
+        relatedPosts {
+          title
+          slug
+          image ${MEDIA_FIELDS}
+          meta ${META_FIELDS}
+        }
       }
     }
   }


### PR DESCRIPTION
Builds a related posts block which renders at the bottom of each blog post. These are hand selected in the post itself. In the future, we can build out some sort of auto population based on taxonomy, or most recent, etc. Here is what this component looks like:

When only 1:

![Screenshot 2023-07-21 at 3 29 10 PM](https://github.com/payloadcms/website/assets/15735305/4c5e07ac-724d-4c5e-8647-7a7f88e1947b)

When 3 or more:
  
![Screenshot 2023-07-21 at 3 29 18 PM](https://github.com/payloadcms/website/assets/15735305/4f562b40-aac7-4dd6-b307-81ae9498e5eb)
