### PR TITLE
uses values from data array instead of priceJSON object

### DIFF
--- a/src/app/cloud/[team-slug]/settings/(tabs)/invoices/client_page.tsx
+++ b/src/app/cloud/[team-slug]/settings/(tabs)/invoices/client_page.tsx
@@ -85,11 +85,7 @@ export const TeamInvoicesPage = () => {
                           >
                             {`${priceFromJSON(
                               JSON.stringify({
-                                data: [
-                                  {
-                                    unit_amount: total,
-                                  },
-                                ],
+                                unit_amount: total,
                               }),
                             )}`}
                           </Heading>

--- a/src/app/cloud/[team-slug]/settings/(tabs)/subscriptions/client_page.tsx
+++ b/src/app/cloud/[team-slug]/settings/(tabs)/subscriptions/client_page.tsx
@@ -114,7 +114,7 @@ const Page = (props: {
                               />
                             </div>
                             <Heading element="h6" marginBottom={false} marginTop={false}>
-                              {`${priceFromJSON(JSON.stringify({ data: [item.price] }))}`}
+                              {`${priceFromJSON(JSON.stringify(item.price))}`}
                             </Heading>
                             {status === 'trialing' && trial_end && (
                               <div>

--- a/src/utilities/price-from-json.ts
+++ b/src/utilities/price-from-json.ts
@@ -4,10 +4,8 @@ export const priceFromJSON = (priceJSON = '{}', showFree = true): string => {
   try {
     const parsed = JSON.parse(priceJSON)
 
-    const priceValue = parsed?.data[0].unit_amount
-    const priceType = parsed?.data[0].type
-    const interval = parsed?.data[0].recurring?.interval
-    const intervalCount = parsed?.data[0].recurring?.interval_count
+    const priceValue = parsed?.unit_amount
+    const priceType = parsed?.type
 
     if (priceValue === undefined && !showFree) {
       return price
@@ -19,9 +17,10 @@ export const priceFromJSON = (priceJSON = '{}', showFree = true): string => {
     })
 
     if (priceType === 'recurring') {
-      price += ` per ${
-        intervalCount === 1 ? interval : `${intervalCount} ${interval}s`
-      }`
+      price += ` per ${parsed.recurring.interval_count > 1
+          ? `${parsed.recurring.interval_count} ${parsed.recurring.interval}`
+          : parsed.recurring.interval
+        }`
     }
   } catch (e: unknown) {
     console.error(`Cannot parse priceJSON`) // eslint-disable-line no-console

--- a/src/utilities/price-from-json.ts
+++ b/src/utilities/price-from-json.ts
@@ -4,8 +4,10 @@ export const priceFromJSON = (priceJSON = '{}', showFree = true): string => {
   try {
     const parsed = JSON.parse(priceJSON)
 
-    const priceValue = parsed?.unit_amount
-    const priceType = parsed?.type
+    const priceValue = parsed?.data[0].unit_amount
+    const priceType = parsed?.data[0].type
+    const interval = parsed?.data[0].recurring?.interval
+    const intervalCount = parsed?.data[0].recurring?.interval_count
 
     if (priceValue === undefined && !showFree) {
       return price
@@ -18,9 +20,7 @@ export const priceFromJSON = (priceJSON = '{}', showFree = true): string => {
 
     if (priceType === 'recurring') {
       price += ` per ${
-        parsed.recurring.interval_count > 1
-          ? `${parsed.recurring.interval_count} ${parsed.recurring.interval}`
-          : parsed.recurring.interval
+        intervalCount === 1 ? interval : `${intervalCount} ${interval}s`
       }`
     }
   } catch (e: unknown) {

--- a/src/utilities/price-from-json.ts
+++ b/src/utilities/price-from-json.ts
@@ -17,10 +17,11 @@ export const priceFromJSON = (priceJSON = '{}', showFree = true): string => {
     })
 
     if (priceType === 'recurring') {
-      price += ` per ${parsed.recurring.interval_count > 1
+      price += ` per ${
+        parsed.recurring.interval_count > 1
           ? `${parsed.recurring.interval_count} ${parsed.recurring.interval}`
           : parsed.recurring.interval
-        }`
+      }`
     }
   } catch (e: unknown) {
     console.error(`Cannot parse priceJSON`) // eslint-disable-line no-console


### PR DESCRIPTION
Closes #209 

Updates the `price-from-json` function to use the `data[0]` object from the parsed `priceJSON`.

Note:
I wasn't able to see the changes on the invoice route, because there wasn't an actual Stripe price for the projects in my dev environment. I was able to see them in the Configure page:

Before:
![Screenshot 2023-07-31 at 1 44 59 PM](https://github.com/payloadcms/website/assets/89618855/a5d9d841-f098-4a71-adc4-dbe1a47f5cab)

After:
![Screenshot 2023-07-31 at 1 45 18 PM](https://github.com/payloadcms/website/assets/89618855/71972262-2550-4d47-b5be-1d71a85ed78e)

The Invoices page uses a similar object structure:
https://github.com/payloadcms/website/blob/ee1d13612f55e3b03f32c40348cac9da4133010d/src/app/cloud/%5Bteam-slug%5D/settings/(tabs)/invoices/client_page.tsx#L86