### PR TITLE
fix: disabled breadcrumb ellipsis on blog, case studies, default hero

### DIFF
--- a/src/app/(pages)/blog/[slug]/BlogPost/index.tsx
+++ b/src/app/(pages)/blog/[slug]/BlogPost/index.tsx
@@ -31,6 +31,7 @@ export const BlogPost: React.FC<
               label: 'Blog Post',
             },
           ]}
+          ellipsis={false}
         />
       </Gutter>
       <Gutter className={classes.blogHeader}>

--- a/src/app/(pages)/case-studies/[slug]/client_page.tsx
+++ b/src/app/(pages)/case-studies/[slug]/client_page.tsx
@@ -29,6 +29,7 @@ export const CaseStudy: React.FC<CaseStudyT> = props => {
               label: title,
             },
           ]}
+          ellipsis={false}
         />
         <Grid>
           <Cell cols={9}>

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -12,14 +12,15 @@ export type Breadcrumb = {
 
 export type Props = {
   items?: Array<Breadcrumb>
+  ellipsis?: boolean
 }
 
-export const Breadcrumbs: React.FC<Props> = ({ items }) => {
+export const Breadcrumbs: React.FC<Props> = ({ items, ellipsis = true }) => {
   return (
     <EdgeScroll element="nav" className={classes.breadcrumbs}>
       {items?.map((item, index) => {
         const isLast = index === items.length - 1
-        const doEllipsis = (item?.label || '')?.length > 8
+        const doEllipsis = ellipsis && (item?.label || '')?.length > 8
 
         if (item?.url && typeof item.url === 'string' && !isLast) {
           return (

--- a/src/components/Hero/Default/index.tsx
+++ b/src/components/Hero/Default/index.tsx
@@ -25,7 +25,7 @@ export const DefaultHero: React.FC<
   return (
     <Gutter>
       <div className={classes.defaultHero}>
-        {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
+        {breadcrumbs && <Breadcrumbs items={breadcrumbs} ellipsis={false} />}
         <Grid>
           <Cell cols={withoutSidebar ? 10 : 8} colsM={withoutSidebar ? 7 : 5} colsS={8}>
             <RichText className={classes.richText} content={richText} />

--- a/src/components/Hero/Livestream/index.tsx
+++ b/src/components/Hero/Livestream/index.tsx
@@ -48,7 +48,9 @@ export const LivestreamHero: React.FC<{
         <Gutter className={classes.gutter}>
           <Grid>
             <Cell cols={6} colsM={8} startM={1}>
-              {breadcrumbs && !hideBreadcrumbs && <Breadcrumbs items={breadcrumbs} />}
+              {breadcrumbs && !hideBreadcrumbs && (
+                <Breadcrumbs items={breadcrumbs} ellipsis={false} />
+              )}
               {richText && <RichText content={richText} />}
               {guests &&
                 Array.isArray(guests) &&


### PR DESCRIPTION
Before:
<img width="799" alt="Screenshot 2023-08-16 at 6 37 41 PM" src="https://github.com/payloadcms/website/assets/67977755/48cb0785-e552-49af-88d8-875d0159ee8e">

After:
<img width="823" alt="Screenshot 2023-08-16 at 6 38 13 PM" src="https://github.com/payloadcms/website/assets/67977755/de8c8f0b-8b8a-4535-b676-cf34771364e3">
