### PR TITLE
Fix: disables browser font-size adjustments

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -90,6 +90,7 @@ html {
 
 body {
   -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   font-family: var(--font-body);
   color: var(--theme-text);
   margin: 0;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -89,6 +89,7 @@ html {
 }
 
 body {
+  -webkit-text-size-adjust: 100%;
   font-family: var(--font-body);
   color: var(--theme-text);
   margin: 0;


### PR DESCRIPTION
Adds `-webkit-text-size-adjust: 100%;` to prevent browsers from scaling font-sizes by default.

| Before | After |
| --- | --- |
| ![IMG_2419](https://github.com/payloadcms/website/assets/89618855/62d3d371-c68b-4515-85bc-3123a447bbc3) | ![IMG_2420](https://github.com/payloadcms/website/assets/89618855/d62f4f82-d29b-4ea0-acb1-0d57f47ae6c1) |
