### PR TITLE
Fix/docs styling

### DIFF
--- a/src/app/(pages)/docs/client_layout.tsx
+++ b/src/app/(pages)/docs/client_layout.tsx
@@ -134,6 +134,7 @@ export const RenderDocs: React.FC<Props> = ({ topics, children }) => {
               </React.Fragment>
             )
           })}
+          <div className={classes.navOverlay} />
         </nav>
         <div className={classes.content}>{children}</div>
         <button

--- a/src/app/(pages)/docs/index.module.scss
+++ b/src/app/(pages)/docs/index.module.scss
@@ -73,6 +73,17 @@
   }
 }
 
+.navOverlay {
+  display: block;
+  position: sticky;
+  width: 100%;
+  height: calc(var(--base) * 2);
+  bottom: calc(var(--base) * -2);
+  left: 0;
+  background: linear-gradient(180deg, transparent 0%, var(--theme-bg) 100%);
+  pointer-events: none;
+}
+
 .navHidden {
   opacity: 0;
 }

--- a/src/app/(pages)/docs/index.module.scss
+++ b/src/app/(pages)/docs/index.module.scss
@@ -77,7 +77,7 @@
   display: block;
   position: sticky;
   width: 100%;
-  height: calc(var(--base) * 2);
+  height: calc(var(--base) * 4);
   bottom: calc(var(--base) * -2);
   left: 0;
   background: linear-gradient(180deg, transparent 0%, var(--theme-bg) 100%);

--- a/src/components/TableOfContents/index.module.scss
+++ b/src/components/TableOfContents/index.module.scss
@@ -8,7 +8,7 @@
   a {
     text-decoration: none;
   }
-  
+
 }
 
 .tocTitle {
@@ -21,7 +21,7 @@
 .heading {
   transition: all 400ms;
   position: relative;
-  line-height: calc(var(--base) * .875);
+  line-height: 1.375;
   margin-bottom: calc(var(--base) * .75);
   margin-right: var(--base);
 


### PR DESCRIPTION
Resolves #199, resolves #200 

### Table of Contents
Uses the same line-height value as the docs navigation.

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-28 at 2 36 27 PM](https://github.com/payloadcms/website/assets/89618855/0c6f2933-8d36-4acf-ade9-595c4d614e62) | ![Screenshot 2023-08-28 at 2 36 03 PM](https://github.com/payloadcms/website/assets/89618855/777404e0-ad95-47a7-98d7-b7b832ab13e6) |

### Overlay
Add a sticky gradient overlay to the bottom of the navigation container.

| Before | After |
| --- | --- |
| ![Screenshot 2023-08-28 at 2 46 09 PM](https://github.com/payloadcms/website/assets/89618855/d2640f33-99b9-47a0-bb0c-32dc6dd30a43) | ![Screenshot 2023-08-28 at 2 45 17 PM](https://github.com/payloadcms/website/assets/89618855/08561b7d-94bd-4624-aef6-e966ea9fab7e) |