### PR TITLE
WIP: Feat/adds plan preview

### DIFF
--- a/src/app/_graphql/plans.ts
+++ b/src/app/_graphql/plans.ts
@@ -4,6 +4,11 @@ export const PLAN = `
   name
   priceJSON
   description
+  highlight
+  features {
+    icon
+    feature
+  }
 `
 
 export const PLANS_QUERY = `

--- a/src/app/_graphql/plans.ts
+++ b/src/app/_graphql/plans.ts
@@ -3,6 +3,7 @@ export const PLAN = `
   slug
   name
   priceJSON
+  description
 `
 
 export const PLANS_QUERY = `

--- a/src/app/cloud/_components/ComparePlans/index.module.scss
+++ b/src/app/cloud/_components/ComparePlans/index.module.scss
@@ -1,0 +1,93 @@
+@use '@scss/common' as *;
+
+.drawerToggle {
+  display: flex;
+  gap: calc(var(--base) / 2);
+  align-items: center;
+  text-decoration: underline;
+  cursor: pointer;
+  color: var(--theme-text);
+  font-size: var(--font-body-size);
+  background: none;
+  border: none;
+}
+
+.compareTable {
+  display: flex;
+  gap: calc(var(--base) * 2);
+  width: 100%;
+
+  @include mid-break {
+    flex-direction: column;
+  }
+}
+
+.planCard {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.pricingCard {
+  aspect-ratio: unset;
+  min-height: calc(var(--base) * 15);
+
+  @include small-break {
+    aspect-ratio: unset;
+    & > span {
+      padding: var(--base);
+    }
+  }
+}
+
+.highlight {
+  color: var(--color-base-950);
+  border-color: var(--color-base-950);
+  background-color: var(--color-success-400);
+}
+
+.features {
+  list-style: none;
+  margin: calc(var(--base) * 2.5) 0;
+  color: var(--color-base-100);
+
+  .feature {
+    margin: var(--base) 0;
+    display: flex;
+  }
+
+  .check,
+  .x {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100%;
+    flex-shrink: 0;
+    width: calc(var(--base) * 1.5);
+    height: calc(var(--base) * 1.5);
+    margin-right: calc(var(--base) * 1.5);
+    justify-items: center;
+  }
+
+  .check {
+    border: 1px solid var(--color-success-500);
+
+    & svg {
+      color: var(--color-success-500);
+    }
+  }
+
+  .x {
+    border: 1px solid var(--color-error-500);
+
+    & svg {
+      color: var(--color-error-500);
+      width: 80%;
+      height: 80%;
+
+      & rect {
+        height: 1.5px;
+      }
+    }
+  }
+}

--- a/src/app/cloud/_components/ComparePlans/index.tsx
+++ b/src/app/cloud/_components/ComparePlans/index.tsx
@@ -1,0 +1,72 @@
+import React, { Fragment } from 'react'
+import { useModal } from '@faceless-ui/modal'
+
+import { PricingCard } from '@components/cards/PricingCard'
+import { Drawer, DrawerToggler } from '@components/Drawer'
+import { ArrowIcon } from '@root/icons/ArrowIcon'
+import { CheckIcon } from '@root/icons/CheckIcon'
+import { CloseIcon } from '@root/icons/CloseIcon'
+import { Plan } from '@root/payload-cloud-types'
+
+import classes from './index.module.scss'
+
+type ComparePlansProps = {
+  plans: Plan[]
+}
+
+export const ComparePlans: React.FC<ComparePlansProps> = props => {
+  const { plans } = props
+
+  return (
+    <Fragment>
+      <DrawerToggler slug={`comparePlans`} className={classes.drawerToggle}>
+        Compare Plans
+        <ArrowIcon />
+      </DrawerToggler>
+      <Drawer slug={`comparePlans`} title={'Compare Plans'} size={plans.length > 2 ? 'l' : 'm'}>
+        <div className={classes.compareTable}>
+          {plans?.map((plan, i) => {
+            const getPrice = plan => {
+              let price = ''
+              if (typeof plan === 'object' && plan !== null && 'priceJSON' in plan) {
+                price = plan?.priceJSON?.toString() || ''
+                const parsed = JSON.parse(price)
+                return (parsed?.unit_amount / 100).toLocaleString('en-US', {
+                  style: 'currency',
+                  currency: 'USD',
+                })
+              }
+            }
+
+            const highlight = plan.highlight ? classes.highlight : ''
+
+            return (
+              <div key={i} className={classes.planCard}>
+                <PricingCard
+                  key={plan.name}
+                  leader={plan.name}
+                  price={getPrice(plan)}
+                  description={plan.description}
+                  className={[classes.pricingCard, highlight].join(' ')}
+                />
+                <ul className={classes.features}>
+                  {plan?.features?.map((feature, i) => {
+                    return (
+                      <li key={i} className={classes.feature}>
+                        <div className={feature.icon && classes[feature.icon]}>
+                          {feature.icon === 'check' && <CheckIcon size="medium" />}
+                          {feature.icon === 'x' && <CloseIcon />}
+                        </div>
+                        {feature.feature}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
+      </Drawer>
+    </Fragment>
+  )
+}

--- a/src/app/cloud/_components/PlanSelector/index.module.scss
+++ b/src/app/cloud/_components/PlanSelector/index.module.scss
@@ -4,4 +4,17 @@
     & > *:not(:last-child) {
         margin-bottom: var(--base);
     }
+
+    .plan {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+
+        & button {
+            @include btnReset;
+            &:hover {
+                cursor: pointer;
+            }
+        }
+    }
 }

--- a/src/app/cloud/_components/PlanSelector/index.tsx
+++ b/src/app/cloud/_components/PlanSelector/index.tsx
@@ -1,8 +1,6 @@
 import React, { Fragment, useEffect } from 'react'
 
-import { Drawer, DrawerToggler } from '@components/Drawer'
 import { LargeRadio } from '@components/LargeRadio'
-import { RichText } from '@components/RichText'
 import { Plan } from '@root/payload-cloud-types'
 
 import classes from './index.module.scss'
@@ -18,10 +16,6 @@ type PlanSelectorProps = {
 export const PlanSelector: React.FC<PlanSelectorProps> = props => {
   const { onChange, value: valueFromProps, plans, initialSelection } = props
 
-  const [planPreview, setPlanPreview] = React.useState({
-    name: '',
-    description: {},
-  })
   const hasInitializedSelection = React.useRef(false)
   const [selectedPlan, setSelectedPlan] = React.useState<Plan | undefined | null>(
     typeof initialSelection === 'string'
@@ -75,33 +69,13 @@ export const PlanSelector: React.FC<PlanSelectorProps> = props => {
                     id={plan.id}
                     value={plan}
                     onChange={setSelectedPlan}
-                    label={
-                      <div className={classes.plan}>
-                        {name}
-                        <DrawerToggler
-                          slug={`planPreview`}
-                          onClick={() =>
-                            setPlanPreview({
-                              name: plan.name,
-                              description: plan.description ?? '',
-                            })
-                          }
-                        >
-                          {/* Add icon here */}
-                          info
-                        </DrawerToggler>
-                      </div>
-                    }
+                    label={<div className={classes.plan}>{name}</div>}
                   />
                 </>
               )
             })}
         </div>
       </div>
-
-      <Drawer slug={`planPreview`} title={planPreview.name} size="s">
-        {planPreview.description && <RichText content={planPreview.description} />}
-      </Drawer>
     </Fragment>
   )
 }

--- a/src/app/cloud/_components/PlanSelector/index.tsx
+++ b/src/app/cloud/_components/PlanSelector/index.tsx
@@ -1,6 +1,8 @@
 import React, { Fragment, useEffect } from 'react'
 
+import { Drawer, DrawerToggler } from '@components/Drawer'
 import { LargeRadio } from '@components/LargeRadio'
+import { RichText } from '@components/RichText'
 import { Plan } from '@root/payload-cloud-types'
 
 import classes from './index.module.scss'
@@ -16,6 +18,10 @@ type PlanSelectorProps = {
 export const PlanSelector: React.FC<PlanSelectorProps> = props => {
   const { onChange, value: valueFromProps, plans, initialSelection } = props
 
+  const [planPreview, setPlanPreview] = React.useState({
+    name: '',
+    description: {},
+  })
   const hasInitializedSelection = React.useRef(false)
   const [selectedPlan, setSelectedPlan] = React.useState<Plan | undefined | null>(
     typeof initialSelection === 'string'
@@ -61,19 +67,41 @@ export const PlanSelector: React.FC<PlanSelectorProps> = props => {
               const checked = selectedPlan?.id === plan?.id
 
               return (
-                <LargeRadio
-                  key={plan.id}
-                  checked={checked}
-                  name={name}
-                  id={plan.id}
-                  value={plan}
-                  onChange={setSelectedPlan}
-                  label={name}
-                />
+                <>
+                  <LargeRadio
+                    key={plan.id}
+                    checked={checked}
+                    name={name}
+                    id={plan.id}
+                    value={plan}
+                    onChange={setSelectedPlan}
+                    label={
+                      <div className={classes.plan}>
+                        {name}
+                        <DrawerToggler
+                          slug={`planPreview`}
+                          onClick={() =>
+                            setPlanPreview({
+                              name: plan.name,
+                              description: plan.description ?? '',
+                            })
+                          }
+                        >
+                          {/* Add icon here */}
+                          info
+                        </DrawerToggler>
+                      </div>
+                    }
+                  />
+                </>
               )
             })}
         </div>
       </div>
+
+      <Drawer slug={`planPreview`} title={planPreview.name} size="s">
+        {planPreview.description && <RichText content={planPreview.description} />}
+      </Drawer>
     </Fragment>
   )
 }

--- a/src/app/new/(checkout)/Checkout.module.scss
+++ b/src/app/new/(checkout)/Checkout.module.scss
@@ -14,9 +14,9 @@
             margin-bottom: calc(var(--base) * 2);
         }
     }
-    
+
     @include mid-break {
-        & > * {    
+        & > * {
             margin-bottom: calc(var(--base) / 2);
         }
     }
@@ -43,7 +43,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--base);
-} 
+}
 
 .sidebarCell {
     position: relative;
@@ -96,6 +96,12 @@
 
 .plansSection {
     margin-bottom: calc(var(--base) * 2);
+}
+
+.plansSectionHeader {
+    display: flex;
+    justify-content: space-between;
+    align-self: center;
 }
 
 .projectDetails {

--- a/src/app/new/(checkout)/Checkout.tsx
+++ b/src/app/new/(checkout)/Checkout.tsx
@@ -6,6 +6,7 @@ import { revalidateCache } from '@cloud/_actions/revalidateCache'
 import { Install } from '@cloud/_api/fetchInstalls'
 import { TeamWithCustomer } from '@cloud/_api/fetchTeam'
 import { BranchSelector } from '@cloud/_components/BranchSelector'
+import { ComparePlans } from '@cloud/_components/ComparePlans'
 import { CreditCardSelector } from '@cloud/_components/CreditCardSelector'
 import { PlanSelector } from '@cloud/_components/PlanSelector'
 import { RepoExists } from '@cloud/_components/RepoExists'
@@ -235,9 +236,12 @@ const Checkout: React.FC<{
             <Cell cols={9} colsM={8}>
               <div>
                 <div className={classes.plansSection}>
-                  <Heading element="h5" marginTop={false}>
-                    Select your plan
-                  </Heading>
+                  <div className={classes.plansSectionHeader}>
+                    <Heading element="h5" marginTop={false}>
+                      Select your plan
+                    </Heading>
+                    <ComparePlans plans={plans} />
+                  </div>
                   <div className={classes.plans}>
                     <PlanSelector
                       plans={plans}

--- a/src/payload-cloud-types.ts
+++ b/src/payload-cloud-types.ts
@@ -143,6 +143,10 @@ export interface Plan {
   id: string;
   name: string;
   slug: string;
+
+  description?: {
+    [k: string]: unknown;
+  }[];
   stripeProductID?: string;
   priceJSON?:
     | {

--- a/src/payload-cloud-types.ts
+++ b/src/payload-cloud-types.ts
@@ -143,10 +143,6 @@ export interface Plan {
   id: string;
   name: string;
   slug: string;
-
-  description?: {
-    [k: string]: unknown;
-  }[];
   stripeProductID?: string;
   priceJSON?:
     | {
@@ -158,6 +154,13 @@ export interface Plan {
     | boolean
     | null;
   order?: number;
+  description?: string;
+  highlight?: boolean;
+  features?: {
+    icon?: 'check' | 'x';
+    feature?: string;
+    id?: string;
+  }[];
   updatedAt: string;
   createdAt: string;
 }
@@ -234,6 +237,7 @@ export interface Template {
   files?: {
     path: string;
     content?: string;
+    encoding?: string;
     id?: string;
   }[];
   updatedAt: string;

--- a/src/payload-cloud-types.ts
+++ b/src/payload-cloud-types.ts
@@ -143,6 +143,7 @@ export interface Plan {
   id: string;
   name: string;
   slug: string;
+  description?: string;
   stripeProductID?: string;
   priceJSON?:
     | {
@@ -154,7 +155,6 @@ export interface Plan {
     | boolean
     | null;
   order?: number;
-  description?: string;
   highlight?: boolean;
   features?: {
     icon?: 'check' | 'x';


### PR DESCRIPTION
I've built out the drawer for the plan comparisons, pulling data now from `cloud-cms` (dependent on [these changes](https://github.com/payloadcms/cloud-cms/pull/93)).

I am struggling to add a way to select the plan from the comparision table. Updating the checkoutState doesn't affect the PlanSelector component, and I'm not sure if that is intentional or not.

### Images of Drawer component:
| Compare Plans button | Drawer | Drawer scrolled |
| --- | --- | --- |
| ![Screenshot 2023-08-31 at 10 01 14 AM](https://github.com/payloadcms/website/assets/89618855/e63b317a-d90d-4709-86cf-494faa415f4b) | ![Screenshot 2023-08-31 at 10 01 25 AM](https://github.com/payloadcms/website/assets/89618855/fa5c85d0-e67b-4bd6-b5ba-3c54d16f28ba) | ![Screenshot 2023-08-31 at 10 01 33 AM](https://github.com/payloadcms/website/assets/89618855/2b72a301-189a-44cb-bb62-70b3564b48e4) |

(Plan prices are from seed data)
