### PR TITLE
Feat/landing page blocks

### DIFF
--- a/src/app/_graphql/blocks.ts
+++ b/src/app/_graphql/blocks.ts
@@ -147,7 +147,6 @@ export const CONTENT_GRID = `
 
 export const CODE_EXAMPLE = `
 ... on CodeExampleBlock {
-  route
   code
   id
   blockType

--- a/src/app/_graphql/blocks.ts
+++ b/src/app/_graphql/blocks.ts
@@ -145,6 +145,38 @@ export const CONTENT_GRID = `
 }
 `
 
+export const CODE_EXAMPLE = `
+... on CodeExampleBlock {
+  route
+  code
+  id
+  blockType
+}
+`
+
+export const MEDIA_EXAMPLE = `
+... on MediaExampleBlock {
+  media ${MEDIA_FIELDS}
+  id
+  blockType
+}
+`
+
+export const EXAMPLE_TABS = `
+...on ExampleTabsBlock {
+  blockType
+  content
+  tabs {
+    label
+    content
+    examples {
+      ${CODE_EXAMPLE}
+      ${MEDIA_EXAMPLE}
+    }
+  }
+}
+`
+
 export const FORM_BLOCK = `
 ...on FormBlock {
   blockType
@@ -297,6 +329,7 @@ export const REUSABLE_CONTENT_BLOCK = `
         ${CODE_FEATURE}
         ${CONTENT}
         ${CONTENT_GRID}
+        ${EXAMPLE_TABS}
         ${FORM_BLOCK}
         ${HOVER_HIGHLIGHTS}
         ${LINK_GRID}

--- a/src/app/_graphql/pages.ts
+++ b/src/app/_graphql/pages.ts
@@ -45,9 +45,7 @@ export const PAGE = `
         title
         hero {
           type
-          commandLine {
-            command
-          }
+          commandLine
           richText
           sidebarContent
           links {

--- a/src/app/_graphql/pages.ts
+++ b/src/app/_graphql/pages.ts
@@ -6,6 +6,7 @@ import {
   CODE_FEATURE,
   CONTENT,
   CONTENT_GRID,
+  EXAMPLE_TABS,
   FORM_BLOCK,
   HOVER_HIGHLIGHTS,
   LINK_GRID,
@@ -44,6 +45,9 @@ export const PAGE = `
         title
         hero {
           type
+          commandLine {
+            command
+          }
           richText
           sidebarContent
           links {
@@ -57,9 +61,18 @@ export const PAGE = `
           }
           media ${MEDIA_FIELDS}
           adjectives {
-            adjective 
+            adjective
           }
           form ${FORM_FIELDS}
+          logoGroup {
+            label
+            logos {
+              logo ${MEDIA_FIELDS}
+            }
+          }
+          carousel {
+            image ${MEDIA_FIELDS}
+          }
           livestream {
             id
             date
@@ -82,6 +95,7 @@ export const PAGE = `
           ${CODE_FEATURE}
           ${CONTENT}
           ${CONTENT_GRID}
+          ${EXAMPLE_TABS}
           ${FORM_BLOCK}
           ${HOVER_HIGHLIGHTS}
           ${LINK_GRID}

--- a/src/blocks/ExampleTabs/Examples/index.module.scss
+++ b/src/blocks/ExampleTabs/Examples/index.module.scss
@@ -1,0 +1,56 @@
+@use "@scss/common" as *;
+
+.examples {
+  width: 100%;
+  position: relative;
+  gap: calc(var(--base) * 2);
+
+  @include mid-break {
+    gap: var(--base);
+  }
+  @include small-break {
+    flex-direction: column;
+  }
+
+  .codeExample {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    max-height: min-content;
+    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
+    aspect-ratio: 16/9;
+  }
+
+  .codeWrap {
+    height: 100%;
+    width: 100%;
+    display: block;
+
+    & > div {
+      height: 100%;
+      width: 100%;
+    }
+  }
+
+  .mediaExample {
+    display: block;
+    width: 100%;
+    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
+  }
+}
+
+.bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: calc(100% + var(--gutter-h));
+    height: 100%;
+    margin-left: calc(var(--gutter-h) / -2);
+    margin-top: calc(var(--gutter-h) / 2);
+    z-index: -1;
+
+    @include mid-break {
+        margin-left: calc(var(--gutter-h) * -1);
+        width: calc(100% + (var(--gutter-h) * 2));
+    }
+}

--- a/src/blocks/ExampleTabs/Examples/index.module.scss
+++ b/src/blocks/ExampleTabs/Examples/index.module.scss
@@ -3,21 +3,13 @@
 .examples {
   width: 100%;
   position: relative;
-  gap: calc(var(--base) * 2);
-
-  @include mid-break {
-    gap: var(--base);
-  }
-  @include small-break {
-    flex-direction: column;
-  }
 
   .codeExample {
     display: flex;
     width: 100%;
     height: 100%;
     max-height: min-content;
-    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
+    @include shadow-lg;
     aspect-ratio: 16/9;
   }
 
@@ -35,7 +27,8 @@
   .mediaExample {
     display: block;
     width: 100%;
-    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
+    background-color: var(--theme-bg);
+    @include shadow-lg;
   }
 }
 
@@ -51,6 +44,7 @@
 
     @include mid-break {
         margin-left: calc(var(--gutter-h) * -1);
+        margin-top: calc(var(--gutter-h) * 2);
         width: calc(100% + (var(--gutter-h) * 2));
     }
 }

--- a/src/blocks/ExampleTabs/Examples/index.tsx
+++ b/src/blocks/ExampleTabs/Examples/index.tsx
@@ -1,0 +1,48 @@
+import { Cell, Grid } from '@faceless-ui/css-grid'
+
+import Code from '@components/Code'
+import { Media } from '@components/Media'
+import { PixelBackground } from '@components/PixelBackground'
+import { CodeExampleBlock, ExampleTabsBlock, MediaExampleBlock } from '@root/payload-types'
+
+import classes from './index.module.scss'
+
+type Props = {
+  examples: ExampleTabsBlock['tabs'][0]['examples']
+}
+
+export const CodeExample: React.FC<CodeExampleBlock> = ({ code }) => {
+  return (
+    <Cell cols={6} colsM={8} className={classes.codeExample}>
+      <div className={classes.codeWrap}>{code && <Code>{code}</Code>}</div>
+    </Cell>
+  )
+}
+
+export const MediaExample: React.FC<MediaExampleBlock> = ({ media }) => {
+  return (
+    <Cell cols={6} colsM={8} className={classes.mediaExample}>
+      {media && typeof media !== 'string' && <Media resource={media} />}
+    </Cell>
+  )
+}
+
+export const Examples: React.FC<Props> = props => {
+  const { examples } = props
+
+  return (
+    <Grid className={classes.examples}>
+      {Array.isArray(examples) &&
+        examples.map((example, i) => {
+          if (example.blockType === 'CodeExampleBlock') {
+            return <CodeExample key={i} {...example} />
+          } else if (example.blockType === 'MediaExampleBlock') {
+            return <MediaExample key={i} {...example} />
+          }
+        })}
+      <div className={classes.bg}>
+        <PixelBackground />
+      </div>
+    </Grid>
+  )
+}

--- a/src/blocks/ExampleTabs/Examples/index.tsx
+++ b/src/blocks/ExampleTabs/Examples/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 export const CodeExample: React.FC<CodeExampleBlock> = ({ code }) => {
   return (
-    <Cell cols={6} colsM={8} className={classes.codeExample}>
+    <Cell cols={6} colsM={4} colsS={8} className={classes.codeExample}>
       <div className={classes.codeWrap}>{code && <Code>{code}</Code>}</div>
     </Cell>
   )
@@ -21,7 +21,7 @@ export const CodeExample: React.FC<CodeExampleBlock> = ({ code }) => {
 
 export const MediaExample: React.FC<MediaExampleBlock> = ({ media }) => {
   return (
-    <Cell cols={6} colsM={8} className={classes.mediaExample}>
+    <Cell cols={6} colsM={4} colsS={8} className={classes.mediaExample}>
       {media && typeof media !== 'string' && <Media resource={media} />}
     </Cell>
   )

--- a/src/blocks/ExampleTabs/Tabs/index.module.scss
+++ b/src/blocks/ExampleTabs/Tabs/index.module.scss
@@ -25,6 +25,10 @@
   width: fit-content;
   border-bottom: solid 1px var(--theme-elevation-200);
 
+  @include extra-small-break {
+    justify-content: flex-start;
+  }
+
   button {
     padding: var(--base) var(--base);
     border: none;

--- a/src/blocks/ExampleTabs/Tabs/index.module.scss
+++ b/src/blocks/ExampleTabs/Tabs/index.module.scss
@@ -1,0 +1,46 @@
+@use "@scss/common" as *;
+
+.tabsContainer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: calc(var(--base) * 2);
+}
+
+.content {
+  text-align: center;
+}
+
+.tabNavigation {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border-bottom: solid 1px var(--theme-elevation-200);
+  overflow: scroll;
+
+  button {
+    padding: var(--base) var(--base);
+    border: none;
+    background-color: transparent;
+    font-size: var(--font-body);
+    color: var(--theme-elevation-500);
+    cursor: pointer;
+    border-bottom: solid 2px transparent;
+
+    &:hover {
+      color: var(--theme-text);
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &.active {
+      color: var(--theme-text);
+      border-bottom: solid 2px var(--theme-text);
+    }
+  }
+}

--- a/src/blocks/ExampleTabs/Tabs/index.module.scss
+++ b/src/blocks/ExampleTabs/Tabs/index.module.scss
@@ -12,14 +12,18 @@
   text-align: center;
 }
 
+.navigationWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
 .tabNavigation {
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  width: 100%;
+  width: fit-content;
   border-bottom: solid 1px var(--theme-elevation-200);
-  overflow: scroll;
 
   button {
     padding: var(--base) var(--base);

--- a/src/blocks/ExampleTabs/Tabs/index.tsx
+++ b/src/blocks/ExampleTabs/Tabs/index.tsx
@@ -16,18 +16,20 @@ export const Tabs: React.FC<Props> = props => {
 
   return (
     <div className={classes.tabsContainer}>
-      <nav className={classes.tabNavigation}>
-        {tabs &&
-          tabs.map((tab, i) => (
-            <button
-              key={i}
-              onClick={() => setActiveTab(i)}
-              className={i === activeTab ? classes.active : ''}
-            >
-              {tab.label}
-            </button>
-          ))}
-      </nav>
+      <div className={classes.navigationWrap}>
+        <nav className={classes.tabNavigation}>
+          {tabs &&
+            tabs.map((tab, i) => (
+              <button
+                key={i}
+                onClick={() => setActiveTab(i)}
+                className={i === activeTab ? classes.active : ''}
+              >
+                {tab.label}
+              </button>
+            ))}
+        </nav>
+      </div>
       {tabs && <RichText content={tabs[activeTab].content} className={classes.content} />}
       {tabs && <Examples examples={tabs[activeTab].examples} />}
     </div>

--- a/src/blocks/ExampleTabs/Tabs/index.tsx
+++ b/src/blocks/ExampleTabs/Tabs/index.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import React, { useState } from 'react'
+
+import { RichText } from '@components/RichText'
+import { ExampleTabsBlock } from '@root/payload-types'
+import { Examples } from '../Examples'
+
+type Props = Pick<ExampleTabsBlock, 'tabs'>
+
+import classes from './index.module.scss'
+
+export const Tabs: React.FC<Props> = props => {
+  const { tabs } = props
+  const [activeTab, setActiveTab] = useState(0)
+
+  return (
+    <div className={classes.tabsContainer}>
+      <nav className={classes.tabNavigation}>
+        {tabs &&
+          tabs.map((tab, i) => (
+            <button
+              key={i}
+              onClick={() => setActiveTab(i)}
+              className={i === activeTab ? classes.active : ''}
+            >
+              {tab.label}
+            </button>
+          ))}
+      </nav>
+      {tabs && <RichText content={tabs[activeTab].content} className={classes.content} />}
+      {tabs && <Examples examples={tabs[activeTab].examples} />}
+    </div>
+  )
+}

--- a/src/blocks/ExampleTabs/index.module.scss
+++ b/src/blocks/ExampleTabs/index.module.scss
@@ -1,0 +1,15 @@
+.exampleTabsBlock {
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--base) * 2);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  p {
+    max-width: 840px;
+  }
+}

--- a/src/blocks/ExampleTabs/index.tsx
+++ b/src/blocks/ExampleTabs/index.tsx
@@ -1,0 +1,19 @@
+import { Gutter } from '@components/Gutter'
+import { RichText } from '@components/RichText'
+import { ExampleTabsBlock } from '@root/payload-types'
+import { Tabs } from './Tabs'
+
+import classes from './index.module.scss'
+
+type Props = ExampleTabsBlock
+
+export const ExampleTabs: React.FC<Props> = exampleTabsFields => {
+  const { content, tabs } = exampleTabsFields
+
+  return (
+    <Gutter className={classes.exampleTabsBlock}>
+      {content && <RichText content={content} className={classes.content} />}
+      {tabs && <Tabs tabs={tabs} />}
+    </Gutter>
+  )
+}

--- a/src/components/Hero/CenteredCarousel/index.module.scss
+++ b/src/components/Hero/CenteredCarousel/index.module.scss
@@ -1,0 +1,119 @@
+@use '@scss/common.scss' as *;
+
+.centeredCarouselHero {
+  background-color: var(--theme-elevation-50);
+  margin-top: calc(-1 * var(--page-padding-top));
+  padding-top: calc(var(--page-padding-top) + var(--base));
+
+  @media (prefers-reduced-motion) {
+    :global(.marquee) {
+      animation: none;
+    }
+  }
+}
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  gap: calc(var(--base) * 2);
+  margin-top: calc(var(--base) * 2);
+}
+
+.commandLine {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+  gap: var(--base);
+  width: 100%;
+  max-width: 540px;
+  padding: calc(var(--base) / 2) var(--base);
+  font-family: var(--font-mono);
+  background-color: var(--theme-elevation-100);
+  @include small;
+  line-height: 1.5;
+  @include extra-small-break {
+    display: none;
+  }
+  @include extra-large-break {
+    width: auto;
+  }
+}
+
+.richText {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  text-align: center;
+
+  p {
+    max-width: 840px;
+  }
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  margin-top: var(--base);
+  margin-bottom: var(--base);
+  padding: 0;
+  gap: var(--base);
+
+  li {
+    list-style: none;
+  }
+
+  @include small-break {
+    flex-direction: column;
+  }
+}
+
+.logoGroup {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--base);
+
+  .logos {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: calc(var(--base) * 3);
+    list-style: none;
+    padding: 0;
+  }
+}
+
+.carousel {
+  background: linear-gradient(180deg,var(--theme-elevation-50) 0%, var(--theme-elevation-100) 50%, var(--theme-bg) 50%);
+
+  div:global(.child) div {
+    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
+    margin: calc(var(--base) * 4) calc(var(--base) * 1);
+  }
+
+  img {
+    display: block;
+    height: 480px;
+    width: auto;
+
+    @include large-break {
+      height: 320px;
+    }
+
+    @include small-break {
+      height: 240px;
+    }
+
+    @include extra-small-break {
+      height: 160px;
+    }
+  }
+}

--- a/src/components/Hero/CenteredCarousel/index.module.scss
+++ b/src/components/Hero/CenteredCarousel/index.module.scss
@@ -19,6 +19,10 @@
   align-items: center;
   gap: calc(var(--base) * 2);
   margin-top: calc(var(--base) * 2);
+
+  @include small-break {
+    gap: var(--base);
+  }
 }
 
 .commandLine {
@@ -95,9 +99,14 @@
   background: linear-gradient(180deg,var(--theme-elevation-50) 0%, var(--theme-elevation-100) 50%, var(--theme-bg) 50%);
 
   div:global(.child) div {
-    box-shadow: 0px 44px 84px -40px rgba(0, 0, 0, 0.25), 0px 4px 44px 0px rgba(0, 0, 0, 0.06);
-    margin: calc(var(--base) * 4) calc(var(--base) * 1);
+    @include shadow-lg;
+    margin: calc(var(--base) * 4) var(--base);
+
+    @include small-break {
+      margin: calc(var(--base) * 2) calc(var(--base) / 2);
+    }
   }
+
 
   img {
     display: block;

--- a/src/components/Hero/CenteredCarousel/index.tsx
+++ b/src/components/Hero/CenteredCarousel/index.tsx
@@ -25,7 +25,7 @@ export const CenteredCarouselHero: React.FC<Page['hero']> = ({
         <div className={classes.wrap}>
           {commandLine && (
             <div className={classes.commandLine}>
-              {commandLine?.command} <CopyToClipboard value={commandLine?.command ?? ''} />
+              {commandLine} <CopyToClipboard value={commandLine ?? ''} />
             </div>
           )}
           <RichText className={classes.richText} content={richText} />

--- a/src/components/Hero/CenteredCarousel/index.tsx
+++ b/src/components/Hero/CenteredCarousel/index.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Marquee from 'react-fast-marquee'
+
+import { Button } from '@components/Button'
+import { CopyToClipboard } from '@components/CopyToClipboard'
+import { Gutter } from '@components/Gutter'
+import { Label } from '@components/Label'
+import { Media } from '@components/Media'
+import { RichText } from '@components/RichText'
+import { Page } from '@root/payload-types'
+
+import classes from './index.module.scss'
+
+export const CenteredCarouselHero: React.FC<Page['hero']> = ({
+  commandLine,
+  richText,
+  links,
+  logoGroup,
+  carousel,
+}) => {
+  return (
+    <div className={classes.centeredCarouselHero}>
+      <Gutter>
+        <div className={classes.wrap}>
+          {commandLine && (
+            <div className={classes.commandLine}>
+              {commandLine?.command} <CopyToClipboard value={commandLine?.command ?? ''} />
+            </div>
+          )}
+          <RichText className={classes.richText} content={richText} />
+          {Array.isArray(links) && (
+            <ul className={classes.actions}>
+              {links.map(({ link }, i) => {
+                return (
+                  <li key={i}>
+                    <Button {...link} appearance={link.appearance} />
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+          <div className={classes.logoGroup}>
+            <Label>{logoGroup?.label}</Label>
+            {Array.isArray(logoGroup?.logos) && (
+              <ul className={classes.logos}>
+                {logoGroup?.logos.map(({ logo }, i) => {
+                  return (
+                    typeof logo !== 'string' && (
+                      <li key={i}>
+                        <Media resource={logo} />
+                      </li>
+                    )
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      </Gutter>
+      <div className={classes.carousel}>
+        {Array.isArray(carousel) && (
+          <Marquee className={classes.slides} speed={35} style={{ overflowY: 'visible' }}>
+            {carousel.map((slide, i) => {
+              return typeof slide.image !== 'string' && <Media key={i} resource={slide.image} />
+            })}
+          </Marquee>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { Page } from '@root/payload-types'
+import { CenteredCarouselHero } from './CenteredCarousel'
 import { ContentMediaHero } from './ContentMedia'
 import { DefaultHero } from './Default'
 import { FormHero } from './FormHero'
@@ -13,6 +14,7 @@ const heroes = {
   home: HomeHero,
   form: FormHero,
   livestream: LivestreamHero,
+  centeredCarousel: CenteredCarouselHero,
 }
 
 export const Hero: React.FC<{

--- a/src/components/RenderBlocks/index.tsx
+++ b/src/components/RenderBlocks/index.tsx
@@ -12,6 +12,7 @@ import { CodeBlock } from '@blocks/CodeBlock'
 import { CodeFeature } from '@blocks/CodeFeature'
 import { ContentBlock } from '@blocks/Content'
 import { ContentGrid } from '@blocks/ContentGrid'
+import { ExampleTabs } from '@blocks/ExampleTabs'
 import { FormBlock } from '@blocks/FormBlock'
 import { HoverHighlights } from '@blocks/HoverHighlights'
 import { LinkGrid } from '@blocks/LinkGrid'
@@ -53,6 +54,7 @@ const blockComponents = {
   reusableContentBlock: ReusableContentBlock,
   pricing: Pricing,
   relatedPosts: RelatedPosts,
+  exampleTabs: ExampleTabs,
 }
 
 type Props = {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -634,9 +634,7 @@ export interface Page {
         id?: string;
       }[];
     };
-    commandLine?: {
-      command?: string;
-    };
+    commandLine?: string;
     richText?: {
       [k: string]: unknown;
     }[];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2005,7 +2005,6 @@ export interface ExampleTabsBlock {
   blockType: 'exampleTabs';
 }
 export interface CodeExampleBlock {
-  route?: string;
   code: string;
   id?: string;
   blockName?: string;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -619,7 +619,7 @@ export interface Page {
   title: string;
   fullTitle?: string;
   hero: {
-    type: 'default' | 'contentMedia' | 'form' | 'home' | 'livestream';
+    type: 'default' | 'contentMedia' | 'form' | 'home' | 'livestream' | 'centeredCarousel';
     livestream?: {
       id?: string;
       date: string;
@@ -633,6 +633,9 @@ export interface Page {
         image?: string | Media;
         id?: string;
       }[];
+    };
+    commandLine?: {
+      command?: string;
     };
     richText?: {
       [k: string]: unknown;
@@ -714,6 +717,17 @@ export interface Page {
       id?: string;
     }[];
     form?: string | Form;
+    logoGroup?: {
+      label?: string;
+      logos?: {
+        logo: string | Media;
+        id?: string;
+      }[];
+    };
+    carousel?: {
+      image: string | Media;
+      id?: string;
+    }[];
   };
   layout: (
     | {
@@ -1275,6 +1289,7 @@ export interface Page {
         blockName?: string;
         blockType: 'stickyHighlights';
       }
+    | ExampleTabsBlock
   )[];
   slug?: string;
   meta?: {
@@ -1361,9 +1376,9 @@ export interface Post {
         blockType: 'reusableContentBlock';
       }
   )[];
+  relatedPosts?: string[] | Post[];
   slug?: string;
   authors: string[] | User[];
-  author?: string | User;
   publishedOn: string;
   meta?: {
     title?: string;
@@ -1606,6 +1621,7 @@ export interface ReusableContent {
         blockName?: string;
         blockType: 'contentGrid';
       }
+    | ExampleTabsBlock
     | {
         formFields: {
           container?: boolean;
@@ -1971,6 +1987,35 @@ export interface ReusableContent {
   )[];
   updatedAt: string;
   createdAt: string;
+}
+export interface ExampleTabsBlock {
+  content?: {
+    [k: string]: unknown;
+  }[];
+  tabs: {
+    label: string;
+    content?: {
+      [k: string]: unknown;
+    }[];
+    examples: (CodeExampleBlock | MediaExampleBlock)[];
+    id?: string;
+  }[];
+  id?: string;
+  blockName?: string;
+  blockType: 'exampleTabs';
+}
+export interface CodeExampleBlock {
+  route?: string;
+  code: string;
+  id?: string;
+  blockName?: string;
+  blockType: 'CodeExampleBlock';
+}
+export interface MediaExampleBlock {
+  media: string | Media;
+  id?: string;
+  blockName?: string;
+  blockType: 'MediaExampleBlock';
 }
 export interface Form {
   id: string;


### PR DESCRIPTION
Adds a Centered Carousel option for heroes and an Example Tabs block.

[Corresponding PR for `website-cms`
](https://github.com/payloadcms/website-cms/pull/42)
## Centered Carousel

![centered-carousel-hero](https://github.com/payloadcms/website/assets/89618855/07830420-86ed-43e7-a42d-7f9fbe5718e9)

## Example Tabs
![example-tabs-block](https://github.com/payloadcms/website/assets/89618855/0ce27337-002b-48d3-9055-88e39614f76e)
