### PR TITLE
fix: github app installation flow

### DIFF
--- a/src/app/cloud/_api/fetchInstalls.ts
+++ b/src/app/cloud/_api/fetchInstalls.ts
@@ -17,6 +17,9 @@ export const fetchInstalls = async (): Promise<Install[]> => {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `JWT ${token}` } : {}),
     },
+    next: {
+      tags: ['installs'],
+    },
     body: JSON.stringify({
       route: `GET /user/installations`,
     }),

--- a/src/app/cloud/_api/fetchRepos.ts
+++ b/src/app/cloud/_api/fetchRepos.ts
@@ -29,6 +29,9 @@ export const fetchRepos = async (args: {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `JWT ${token}` } : {}),
       },
+      next: {
+        tags: ['repos'],
+      },
       body: JSON.stringify({
         route: `GET /user/installations/${installID}/repositories?${new URLSearchParams({
           per_page: per_page?.toString() ?? '30',
@@ -38,7 +41,7 @@ export const fetchRepos = async (args: {
     },
   )
     ?.then(res => {
-      if (!res.ok) throw new Error(`Error getting repositories: ${res.status}`)
+      if (!res.ok) throw new Error(`Error getting repositories: ${res.status} ${res.statusText}`)
       return res.json()
     })
     ?.then(res => {

--- a/src/app/cloud/_components/InstallationButton/index.tsx
+++ b/src/app/cloud/_components/InstallationButton/index.tsx
@@ -1,25 +1,23 @@
-import React, { useMemo } from 'react'
-import { v4 as uuid } from 'uuid'
+import React, { useState } from 'react'
 
 import { usePopupWindow } from '@root/utilities/use-popup-window'
 
 import classes from './index.module.scss'
 
-// generate an id to use for the state
-// this will be validated after the the redirect back
-const id = uuid()
-const href = `https://github.com/apps/payload-cms/installations/new?state=${id}`
-
 export const InstallationButton: React.FC<{
-  onInstallation?: (installationId: number) => void // eslint-disable-line no-unused-vars
+  onInstall?: (installationId: number) => void // eslint-disable-line no-unused-vars
   label?: string
-}> = ({ onInstallation, label }) => {
+  uuid: string
+}> = ({ onInstall, label, uuid }) => {
+  // this will be validated after the redirect back
+  const [href] = useState(`https://github.com/apps/payload-cms/installations/new?state=${uuid}`)
+
   const { openPopupWindow } = usePopupWindow({
     href,
     eventType: 'github',
     onMessage: async (searchParams: { state: string; installation_id: string }) => {
-      if (searchParams.state === id && typeof onInstallation === 'function') {
-        onInstallation(parseInt(searchParams.installation_id, 10))
+      if (searchParams.state === uuid && typeof onInstall === 'function') {
+        onInstall(parseInt(searchParams.installation_id, 10))
       }
     },
   })
@@ -30,20 +28,4 @@ export const InstallationButton: React.FC<{
       {label || 'Install the Payload App'}
     </a>
   )
-}
-
-export const useInstallationButton = (args?: {
-  onInstallation: (installationId: number) => void // eslint-disable-line no-unused-vars
-  label?: string
-}): [React.FC] => {
-  const { onInstallation, label } = args || {}
-
-  const MemoizedInstallationButton = useMemo(
-    () => () => {
-      return <InstallationButton onInstallation={onInstallation} label={label} />
-    },
-    [onInstallation, label],
-  )
-
-  return [MemoizedInstallationButton]
 }

--- a/src/app/cloud/_components/InstallationSelector/components/MenuList/index.module.scss
+++ b/src/app/cloud/_components/InstallationSelector/components/MenuList/index.module.scss
@@ -1,0 +1,15 @@
+@use '@scss/common' as *;
+
+.addAccountButton {
+    display: block;
+    background-color: transparent;
+    margin: 0;
+    padding:0;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    text-align: left;
+    line-height: inherit;
+    font-size: inherit;
+    padding: calc(var(--base) / 2) var(--base);
+}

--- a/src/app/cloud/_components/InstallationSelector/components/MenuList/index.tsx
+++ b/src/app/cloud/_components/InstallationSelector/components/MenuList/index.tsx
@@ -1,0 +1,19 @@
+import { components } from 'react-select'
+
+import classes from './index.module.scss'
+
+export const MenuList: React.FC<any> = props => {
+  const {
+    selectProps: { selectProps, href },
+  } = props
+
+  return (
+    <components.MenuList {...props}>
+      {props.children}
+      {/* use an anchor tag with an href despite the onClick for better UX */}
+      <a className={classes.addAccountButton} href={href} onClick={selectProps?.openPopupWindow}>
+        Install GitHub app
+      </a>
+    </components.MenuList>
+  )
+}

--- a/src/app/cloud/_components/InstallationSelector/components/Option/index.module.scss
+++ b/src/app/cloud/_components/InstallationSelector/components/Option/index.module.scss
@@ -1,0 +1,23 @@
+@use '@scss/common' as *;
+
+.option {
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+}
+
+.githubIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: calc(var(--base) * 1);
+    height: calc(var(--base) * 1);
+    margin-right: calc(var(--base) * 0.5);
+    flex-shrink: 0;
+}
+
+.optionLabel {
+    flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/app/cloud/_components/InstallationSelector/components/Option/index.tsx
+++ b/src/app/cloud/_components/InstallationSelector/components/Option/index.tsx
@@ -1,0 +1,18 @@
+import { components } from 'react-select'
+
+import { GitHubIcon } from '@root/graphics/GitHub'
+
+import classes from './index.module.scss'
+
+export const Option: React.FC<any> = props => {
+  return (
+    <components.Option {...props}>
+      <div className={classes.option}>
+        <div className={classes.githubIcon}>
+          <GitHubIcon />
+        </div>
+        <div className={classes.optionLabel}>{props.label}</div>
+      </div>
+    </components.Option>
+  )
+}

--- a/src/app/cloud/_components/InstallationSelector/components/SingleValue/index.module.scss
+++ b/src/app/cloud/_components/InstallationSelector/components/SingleValue/index.module.scss
@@ -1,0 +1,23 @@
+@use '@scss/common' as *;
+
+.option {
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+}
+
+.githubIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: calc(var(--base) * 1);
+    height: calc(var(--base) * 1);
+    margin-right: calc(var(--base) * 0.5);
+    flex-shrink: 0;
+}
+
+.optionLabel {
+    flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/app/cloud/_components/InstallationSelector/components/SingleValue/index.tsx
+++ b/src/app/cloud/_components/InstallationSelector/components/SingleValue/index.tsx
@@ -1,0 +1,18 @@
+import { components } from 'react-select'
+
+import { GithubIcon } from '@root/graphics/GithubIcon'
+
+import classes from './index.module.scss'
+
+export const SingleValue: React.FC<any> = props => {
+  return (
+    <components.SingleValue {...props}>
+      <div className={classes.option}>
+        <div className={classes.githubIcon}>
+          <GithubIcon />
+        </div>
+        <div className={classes.optionLabel}>{props.children}</div>
+      </div>
+    </components.SingleValue>
+  )
+}

--- a/src/app/cloud/_components/InstallationSelector/index.module.scss
+++ b/src/app/cloud/_components/InstallationSelector/index.module.scss
@@ -1,41 +1,5 @@
 @use '@scss/common' as *;
 
-.addAccountButton {
-    display: block;
-    background-color: transparent;
-    margin: 0;
-    padding:0;
-    border: none;
-    outline: none;
-    cursor: pointer;
-    text-align: left;
-    line-height: inherit;
-    font-size: inherit;
-    padding: calc(var(--base) / 2) var(--base);
-}
-
-.option {
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-}
-
-.githubIcon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: calc(var(--base) * 1);
-    height: calc(var(--base) * 1);
-    margin-right: calc(var(--base) * 0.5);
-    flex-shrink: 0;
-}
-
-.optionLabel {
-    flex-grow: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
 .description {
     @include small;
     margin-top: calc(var(--base) / 2);

--- a/src/app/cloud/_components/InstallationSelector/index.tsx
+++ b/src/app/cloud/_components/InstallationSelector/index.tsx
@@ -1,91 +1,34 @@
-import React, { Fragment, useEffect, useMemo } from 'react'
-import { components } from 'react-select'
+import React, { Fragment, useEffect, useState } from 'react'
 import { Install } from '@cloud/_api/fetchInstalls'
 import { Select } from '@forms/fields/Select'
 import Label from '@forms/Label'
-import { v4 as uuid } from 'uuid'
 
 import { LoadingShimmer } from '@components/LoadingShimmer'
-import { GitHubIcon } from '@root/graphics/GitHub'
-import useDebounce from '@root/utilities/use-debounce'
 import { usePopupWindow } from '@root/utilities/use-popup-window'
-import { UseGetInstalls, useGetInstalls } from './useGetInstalls'
+import { MenuList } from './components/MenuList'
+import { Option } from './components/Option'
+import { SingleValue } from './components/SingleValue'
+import { InstallationSelectorProps } from './types'
 
 import classes from './index.module.scss'
-
-// generate an id to use for the state
-// this will be validated after the the redirect back
-const id = uuid()
-const href = `https://github.com/apps/payload-cms/installations/new?state=${id}`
-
-const SelectMenuButton = props => {
-  const {
-    selectProps: { selectProps },
-  } = props
-
-  return (
-    <components.MenuList {...props}>
-      {props.children}
-      {/* use an anchor tag with an href despite the onClick for better UX */}
-      <a className={classes.addAccountButton} href={href} onClick={selectProps?.openPopupWindow}>
-        Install GitHub app
-      </a>
-    </components.MenuList>
-  )
-}
-
-const SingleValue = props => {
-  return (
-    <components.SingleValue {...props}>
-      <div className={classes.option}>
-        <div className={classes.githubIcon}>
-          <GitHubIcon />
-        </div>
-        <div className={classes.optionLabel}>{props.children}</div>
-      </div>
-    </components.SingleValue>
-  )
-}
-
-const Option = props => {
-  return (
-    <components.Option {...props}>
-      <div className={classes.option}>
-        <div className={classes.githubIcon}>
-          <GitHubIcon />
-        </div>
-        <div className={classes.optionLabel}>{props.label}</div>
-      </div>
-    </components.Option>
-  )
-}
-
-type InstallationSelectorProps = {
-  value?: Install['id']
-  onChange?: (value?: Install) => void // eslint-disable-line no-unused-vars
-  installs?: Install[]
-  reloadInstalls: ReturnType<UseGetInstalls>['reload']
-  loading?: boolean
-  error?: string
-  description?: string
-  disabled?: boolean
-  hideLabel?: boolean
-  className?: string
-}
 
 export const InstallationSelector: React.FC<InstallationSelectorProps> = props => {
   const {
     onChange,
     value: valueFromProps,
     installs,
-    reloadInstalls,
+    onInstall,
     error,
     loading,
     description,
     disabled,
     hideLabel,
     className,
+    uuid,
   } = props
+
+  // this will be validated after the redirect back
+  const [href] = useState(`https://github.com/apps/payload-cms/installations/new?state=${uuid}`)
 
   const selectAfterLoad = React.useRef<Install['id']>()
 
@@ -105,9 +48,9 @@ export const InstallationSelector: React.FC<InstallationSelectorProps> = props =
     href,
     eventType: 'github',
     onMessage: async (searchParams: { state: string; installation_id: string }) => {
-      if (searchParams.state === id) {
+      if (searchParams.state === uuid) {
         selectAfterLoad.current = parseInt(searchParams.installation_id, 10)
-        reloadInstalls()
+        if (typeof onInstall === 'function') onInstall()
       }
     },
   })
@@ -159,9 +102,10 @@ export const InstallationSelector: React.FC<InstallationSelectorProps> = props =
           ]}
           selectProps={{
             openPopupWindow,
+            href,
           }}
           components={{
-            MenuList: SelectMenuButton,
+            MenuList,
             Option,
             SingleValue,
           }}
@@ -171,64 +115,4 @@ export const InstallationSelector: React.FC<InstallationSelectorProps> = props =
       {description && <p className={classes.description}>{description}</p>}
     </div>
   )
-}
-
-type UseInstallationSelectorArgs = Parameters<UseGetInstalls>[0] & {
-  initialInstallID?: string
-  onChange?: (value?: Install) => void
-  hideLabel?: boolean
-}
-
-export const useInstallationSelector = (
-  args: UseInstallationSelectorArgs = {},
-): [
-  React.FC<{
-    description?: string
-    disabled?: boolean
-    hideLabel?: boolean
-  }>,
-  ReturnType<UseGetInstalls> & {
-    value?: Install
-    description?: string
-  },
-] => {
-  const { initialInstallID, permissions, installs: initialInstalls, onChange } = args
-  const [value, setValue] = React.useState<Install | undefined>(initialInstalls?.[0])
-  const installsData = useGetInstalls({ permissions, installs: initialInstalls })
-  const { error, installs, reload, loading } = installsData
-
-  const debouncedLoading = useDebounce(loading, 250)
-
-  const MemoizedInstallationSelector = useMemo(
-    () =>
-      ({ description, disabled, hideLabel }) => {
-        return (
-          <InstallationSelector
-            value={initialInstallID ? Number(initialInstallID) : undefined}
-            loading={debouncedLoading}
-            error={error}
-            installs={installs}
-            reloadInstalls={reload}
-            hideLabel={hideLabel}
-            onChange={(setV: Install) => {
-              setValue(setV)
-              if (typeof onChange === 'function') {
-                onChange(setV)
-              }
-            }}
-            description={description}
-            disabled={disabled}
-          />
-        )
-      },
-    [error, installs, reload, debouncedLoading, initialInstallID, onChange],
-  )
-
-  return [
-    MemoizedInstallationSelector,
-    {
-      ...installsData,
-      value,
-    },
-  ]
 }

--- a/src/app/cloud/_components/InstallationSelector/types.ts
+++ b/src/app/cloud/_components/InstallationSelector/types.ts
@@ -1,0 +1,15 @@
+import type { Install } from '@cloud/_api/fetchInstalls'
+
+export interface InstallationSelectorProps {
+  value?: Install['id']
+  onChange?: (value?: Install) => void // eslint-disable-line no-unused-vars
+  installs?: Install[]
+  onInstall?: () => void
+  loading?: boolean
+  error?: string
+  description?: string
+  disabled?: boolean
+  hideLabel?: boolean
+  className?: string
+  uuid: string
+}

--- a/src/app/new/clone/[template-slug]/page.tsx
+++ b/src/app/new/clone/[template-slug]/page.tsx
@@ -10,6 +10,7 @@ import { Breadcrumbs } from '@components/Breadcrumbs'
 import { Gutter } from '@components/Gutter'
 import { Heading } from '@components/Heading'
 import { mergeOpenGraph } from '@root/seo/mergeOpenGraph'
+import { uuid as generateUUID } from '@root/utilities/uuid'
 import { CloneTemplate } from './page_client'
 
 const title = `Create new from template`
@@ -39,6 +40,8 @@ export default async ({ params: { 'template-slug': templateSlug } }) => {
 
   const installs = await fetchInstalls()
 
+  const uuid = generateUUID()
+
   return (
     <Fragment>
       <Gutter>
@@ -61,7 +64,7 @@ export default async ({ params: { 'template-slug': templateSlug } }) => {
           {title}
         </Heading>
       </Gutter>
-      {<CloneTemplate template={template} installs={installs} user={user} />}
+      {<CloneTemplate template={template} installs={installs} user={user} uuid={uuid} />}
     </Fragment>
   )
 }

--- a/src/app/new/import/page.tsx
+++ b/src/app/new/import/page.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import { fetchGitHubToken } from '@cloud/_api/fetchGitHubToken'
 import { fetchInstalls } from '@cloud/_api/fetchInstalls'
 import { fetchMe } from '@cloud/_api/fetchMe'
-import { fetchRepos } from '@cloud/_api/fetchRepos'
+import { fetchRepos, Repo, RepoResults } from '@cloud/_api/fetchRepos'
 import { Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
@@ -10,6 +10,7 @@ import { Breadcrumbs } from '@components/Breadcrumbs'
 import { Gutter } from '@components/Gutter'
 import { Heading } from '@components/Heading'
 import { mergeOpenGraph } from '@root/seo/mergeOpenGraph'
+import { uuid as generateUUID } from '@root/utilities/uuid'
 import { ImportProject } from './page_client'
 
 const title = `Import a codebase`
@@ -33,9 +34,15 @@ export default async () => {
 
   const installs = await fetchInstalls()
 
-  const repos = await fetchRepos({
-    install: installs[0],
-  })
+  let repos: RepoResults | undefined
+
+  if (Array.isArray(installs) && installs.length > 0) {
+    repos = await fetchRepos({
+      install: installs[0],
+    })
+  }
+
+  const uuid = generateUUID()
 
   return (
     <Fragment>
@@ -57,7 +64,7 @@ export default async () => {
           </Heading>
         </div>
       </Gutter>
-      <ImportProject installs={installs} repos={repos} />
+      <ImportProject installs={installs} repos={repos} uuid={uuid} user={user} />
     </Fragment>
   )
 }

--- a/src/app/new/import/page_client.tsx
+++ b/src/app/new/import/page_client.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import React, { useCallback, useReducer } from 'react'
-import { Install } from '@cloud/_api/fetchInstalls'
+import React, { Fragment, useCallback, useReducer, useState } from 'react'
+import { fetchInstalls, Install } from '@cloud/_api/fetchInstalls'
 import { RepoResults } from '@cloud/_api/fetchRepos'
-import { useInstallationSelector } from '@cloud/_components/InstallationSelector'
+import { InstallationButton } from '@cloud/_components/InstallationButton'
+import { InstallationSelector } from '@cloud/_components/InstallationSelector'
 import { useTeamDrawer } from '@cloud/_components/TeamDrawer'
 import { cloudSlug } from '@cloud/slug'
 import { Cell, Grid } from '@faceless-ui/css-grid'
@@ -14,9 +15,9 @@ import FormSubmissionError from '@forms/FormSubmissionError'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { Gutter } from '@components/Gutter'
+import { Heading } from '@components/Heading'
 import { Pagination } from '@components/Pagination'
 import { Team } from '@root/payload-cloud-types'
-import { useAuth } from '@root/providers/Auth'
 import { createDraftProject } from '../createDraftProject'
 import { RepoCard } from './RepoCard'
 import { useGetRepos } from './useGetRepos'
@@ -27,26 +28,30 @@ const perPage = 30
 
 export const ImportProject: React.FC<{
   installs: Install[]
-  repos: RepoResults
+  repos?: RepoResults
+  uuid: string
+  user: any
 }> = props => {
-  const { installs: initialInstalls, repos: initialRepos } = props
+  const { installs: initialInstalls, repos: initialRepos, uuid, user } = props
   const searchParams = useSearchParams()
   const teamParam = searchParams?.get('team')
-  const { user } = useAuth()
-
   const router = useRouter()
   const submitButtonRef = React.useRef<HTMLButtonElement | null>(null)
   const formRef = React.useRef<HTMLFormElement | null>(null)
   const [hoverIndex, setHoverIndex] = React.useState<number | undefined>(undefined)
   const [repoReloadTicker, reloadRepos] = useReducer(count => count + 1, 0)
 
-  const [
-    InstallationSelector,
-    { value: selectedInstall, installs, loading: loadingInstalls, reload: reloadInstalls },
-  ] = useInstallationSelector({
-    installs: initialInstalls,
-    onChange: reloadRepos,
-  })
+  const [installs, setInstalls] = React.useState<Install[]>(initialInstalls || [])
+
+  const [selectedInstall, setSelectedInstall] = React.useState<Install | undefined>(
+    installs?.[0] || undefined,
+  )
+
+  const onInstall = useCallback(async () => {
+    const freshInstalls = await fetchInstalls()
+    setInstalls(freshInstalls)
+    reloadRepos()
+  }, [])
 
   const {
     loading: loadingRepos,
@@ -134,6 +139,10 @@ export const ImportProject: React.FC<{
               <InstallationSelector
                 description="Select the org or user to import from."
                 hideLabel
+                installs={installs}
+                onChange={setSelectedInstall}
+                onInstall={onInstall}
+                uuid={uuid}
               />
               <p className={classes.appPermissions}>
                 {`Don't see your repository? `}
@@ -147,69 +156,82 @@ export const ImportProject: React.FC<{
           <Cell cols={8} colsM={8}>
             {installs?.length === 0 && (
               <div className={classes.noRepos}>
-                <h6>No installations found</h6>
+                <Heading marginTop={false} element="h6">
+                  No installations found
+                </Heading>
                 <p>
                   {`No installations were found under this profile. To see your repositories, you must first `}
-                  {/* <InstallationButton /> */}
+                  <InstallationButton
+                    label="install the GitHub Payload app"
+                    onInstall={onInstall}
+                    uuid={uuid}
+                  />
                   {'.'}
                 </p>
               </div>
             )}
-            {installs?.length > 0 && cardArray?.length > 0 ? (
-              <RadioGroup
-                className={[classes.repos, loadingRepos && classes.loading]
-                  .filter(Boolean)
-                  .join(' ')}
-                initialValue=""
-                path="repositoryName"
-                layout="vertical"
-                hidden
-                required
-                onChange={onRepoChange}
-                options={cardArray?.map((repo, index) => {
-                  const isHovered = hoverIndex === index
+            {installs?.length > 0 && (
+              <Fragment>
+                {cardArray?.length > 0 ? (
+                  <RadioGroup
+                    className={[classes.repos, loadingRepos && classes.loading]
+                      .filter(Boolean)
+                      .join(' ')}
+                    initialValue=""
+                    path="repositoryName"
+                    layout="vertical"
+                    hidden
+                    required
+                    onChange={onRepoChange}
+                    options={cardArray?.map((repo, index) => {
+                      const isHovered = hoverIndex === index
 
-                  return {
-                    value: repo?.name,
-                    label: (
-                      <RepoCard
-                        key={index}
-                        repo={repo}
-                        isHovered={isHovered}
-                        isLoading={loadingRepos}
-                        onMouseEnter={() => setHoverIndex(index)}
-                        onMouseLeave={() => setHoverIndex(undefined)}
-                        onClick={async repo => {
-                          try {
-                            await createDraftProject({
-                              repo,
-                              teamID: matchedTeam?.id,
-                              installID: selectedInstall?.id,
-                              onSubmit: onDraftProjectCreate,
-                              user,
-                            })
-                          } catch (error) {
-                            window.scrollTo(0, 0)
-                            console.error(error) // eslint-disable-line no-console
-                          }
-                        }}
-                      />
-                    ),
-                  }
-                })}
-              />
-            ) : (
-              <div className={classes.noRepos}>
-                <h6>No repositories found</h6>
-                <p className={classes.appPermissions}>
-                  {`No repositories were found in the account "${selectedInstall?.account?.login}". Create a new repository or `}
-                  <a href={selectedInstall?.html_url} rel="noopener noreferrer" target="_blank">
-                    adjust your GitHub app permissions
-                  </a>
-                  {'.'}
-                </p>
-              </div>
+                      return {
+                        value: repo?.name,
+                        label: (
+                          <RepoCard
+                            key={index}
+                            repo={repo}
+                            isHovered={isHovered}
+                            isLoading={loadingRepos}
+                            onMouseEnter={() => setHoverIndex(index)}
+                            onMouseLeave={() => setHoverIndex(undefined)}
+                            onClick={async repo => {
+                              try {
+                                await createDraftProject({
+                                  repo,
+                                  teamID: matchedTeam?.id,
+                                  installID: selectedInstall?.id,
+                                  onSubmit: onDraftProjectCreate,
+                                  user,
+                                })
+                              } catch (error) {
+                                window.scrollTo(0, 0)
+                                console.error(error) // eslint-disable-line no-console
+                              }
+                            }}
+                          />
+                        ),
+                      }
+                    })}
+                  />
+                ) : (
+                  <div className={classes.noRepos}>
+                    <Heading marginTop={false} element="h6">
+                      No repositories found
+                    </Heading>
+                    <p className={classes.appPermissions}>
+                      {`No repositories were found in the account "${selectedInstall?.account?.login}". Create a new repository or `}
+                      <a href={selectedInstall?.html_url} rel="noopener noreferrer" target="_blank">
+                        adjust your GitHub app permissions
+                      </a>
+                      {'.'}
+                    </p>
+                  </div>
+                )}
+              </Fragment>
             )}
+
             {installs?.length > 0 && results?.total_count / perPage > 1 && (
               <Pagination
                 page={page}

--- a/src/utilities/use-popup-window.ts
+++ b/src/utilities/use-popup-window.ts
@@ -22,6 +22,11 @@ export const usePopupWindow = (props: {
   const { href, onMessage, eventType } = props
   const isReceivingMessage = useRef(false)
 
+  // NOTE: GitHub allows multiple redirect URIs to be set in the App Settings, one for each environment using this App
+  // But there is a known issue when working locally where GitHub will redirect back to the first valid redirect URI in the list
+  // This is likely because the local domain is insecure (http://local.payloadcms.com), and so it's falling back (https://payloadcms.com)
+  // This means that locally installing the GitHub app will not properly redirect you, the page will simply remain as-is
+  // Instead of expecting a redirect, you'll just need to refresh the page after installing the app
   useEffect(() => {
     const receiveMessage = async (event: MessageEvent): Promise<void> => {
       if (event.origin !== window.location.origin) {


### PR DESCRIPTION
Fixes the GitHub app installation flow. Previously, when the user had no repos, this was throwing an error on the server and rendering an error page on the client. Now, we safely handle these cases. The following page also needed some updates, it was rendering irrelevant content on the screen, etc. But more importantly, the `InstallationSelector` was far too complex to the point of it being unmanageable. This PR completely removes the `useInstallationSelector` in favor of a more straightforward approach.