### PR TITLE
chore: updates blog results css in doc search + centers related help list

### DIFF
--- a/src/components/Header/Docsearch/Component.tsx
+++ b/src/components/Header/Docsearch/Component.tsx
@@ -1,12 +1,24 @@
 import React from 'react'
 import { DocSearch } from '@docsearch/react'
 
+import classes from './index.module.scss'
+
+function Hit({ hit, children }) {
+  const blog = hit?.url?.includes('/blog/') || false
+  return (
+    <a className={blog ? classes.blogResult : ''} href={hit?.url}>
+      {children}
+    </a>
+  )
+}
+
 function Component() {
   return (
     <DocSearch
       appId="9MJY7K9GOW"
       indexName="payloadcms"
       apiKey={process.env.NEXT_PUBLIC_ALGOLIA_DOCSEARCH_KEY || ''}
+      hitComponent={Hit}
     />
   )
 }

--- a/src/components/Header/Docsearch/index.module.scss
+++ b/src/components/Header/Docsearch/index.module.scss
@@ -9,3 +9,25 @@
     margin:0;
   }
 }
+
+.blogResult {
+  :global(.DocSearch-Hit-path) {
+    color: inherit;
+
+    &::before {
+      content: 'Blog - ';
+    }
+  }
+
+  :global(.DocSearch-Hit-icon) {
+    &::before {
+      content: "\25B2";
+      display: flex;
+      align-items: center;
+    }
+
+    & svg { 
+      display: none;
+    }
+  }
+}

--- a/src/components/Header/Docsearch/index.module.scss
+++ b/src/components/Header/Docsearch/index.module.scss
@@ -21,9 +21,11 @@
 
   :global(.DocSearch-Hit-icon) {
     &::before {
-      content: "\25B2";
+      content: "\2636";
+      font-size: 25px;
       display: flex;
       align-items: center;
+      transform: translateY(2px);
     }
 
     & svg { 

--- a/src/components/RelatedHelpList/index.module.scss
+++ b/src/components/RelatedHelpList/index.module.scss
@@ -31,7 +31,7 @@
     left: 0;
     top: 0;
     width: 20px;
-    margin: 7px 0 0 0;
+    height: 100%;
 
     @include small-break {
       margin: 3px 0 0 0;


### PR DESCRIPTION
Updates icon and prefixes path for blog results in the doc search.

Before
<img width="624" alt="before" src="https://github.com/payloadcms/website/assets/67977755/b90fa110-073b-4d4b-b5e3-2f59907ca4aa">

After
<img width="626" alt="after" src="https://github.com/payloadcms/website/assets/67977755/5fe1faa7-5a93-44db-9854-765bcc067fa7">

Centers related help icon and text
Before
<img width="456" alt="Screenshot 2023-11-01 at 7 05 32 PM" src="https://github.com/payloadcms/website/assets/67977755/01a4f2d1-86a2-483a-b6a5-618f29e47ca5">
After
<img width="430" alt="Screenshot 2023-11-01 at 7 05 45 PM" src="https://github.com/payloadcms/website/assets/67977755/c5b70f07-393c-4b56-92e8-2f83c776d022">
