### PR TITLE
fix: broken internal links

### DIFF
--- a/src/components/CMSLink/index.tsx
+++ b/src/components/CMSLink/index.tsx
@@ -55,12 +55,7 @@ const generateHref = (args: GenerateSlugType): string => {
     return url
   }
 
-  if (
-    type === 'reference' &&
-    reference?.value &&
-    typeof reference.value !== 'string' &&
-    reference.value.slug
-  ) {
+  if (type === 'reference' && reference?.value && typeof reference.value !== 'string') {
     if (reference.relationTo === 'pages') {
       const value = reference.value as Page
       const breadcrumbs = value?.breadcrumbs


### PR DESCRIPTION
Fixes an issue where internal links were looking for `reference.value.slug`, causing them to be break.