### PR TITLE
fix: updates ellipsis max-width for breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/index.module.scss
+++ b/src/components/Breadcrumbs/index.module.scss
@@ -16,7 +16,7 @@
 .ellipsis {
   overflow: hidden;
   width: 100%;
-  max-width: 75px;
+  max-width: max-content;
 }
 
 .labelContent {


### PR DESCRIPTION
Fix #286

Desktop:
![Screen Shot 2024-01-03 at 9 42 30 AM](https://github.com/payloadcms/website/assets/35232443/78fac2ea-a0a5-42b5-81b6-3698b6023819)


Mobile:
![Screen Shot 2024-01-03 at 9 42 38 AM](https://github.com/payloadcms/website/assets/35232443/26177065-b830-4b02-9531-45d90fb66ccf)
