### PR TITLE
fix: better responsiveness for square cards

### DIFF
--- a/src/blocks/CardGrid/index.tsx
+++ b/src/blocks/CardGrid/index.tsx
@@ -58,7 +58,7 @@ export const CardGrid: React.FC<CardGridProps> = props => {
               {cards.map((card, index) => {
                 const { title, description, link } = card
                 return (
-                  <Cell key={index} cols={3} colsL={4} colsM={4} colsS={4}>
+                  <Cell key={index} cols={4}>
                     <SquareCard
                       leader={(index + 1).toString().padStart(2, '0')}
                       className={classes.card}


### PR DESCRIPTION
Changes the Square Cards block to use 3 columns at all breakpoints, which makes for better responsive sizing for cards with lots of content.

**Before:**
![Screenshot 2024-01-16 at 11 54 16 AM](https://github.com/payloadcms/website/assets/89618855/2baed2a7-a409-48ed-a0f7-06adabdf1874)

**After:**
![Screenshot 2024-01-16 at 11 54 30 AM](https://github.com/payloadcms/website/assets/89618855/777ccc4e-746e-414f-b9b2-1cd7cfac8b37)

