### PR TITLE
fix: hides gradient bg on breadcrumb label on non-small screens

### DIFF
--- a/src/components/EdgeScroll/index.module.scss
+++ b/src/components/EdgeScroll/index.module.scss
@@ -46,10 +46,15 @@
     left: 0;
     background: linear-gradient(90deg, var(--theme-bg), transparent);
   }
-  
+
   &.right {
-    left: 0;
-    background: linear-gradient(-90deg, var(--theme-bg), transparent);
-    margin-left: auto;
+    display: none;
+
+    @include mid-break {
+      display: block;
+      left: 0;
+      background: linear-gradient(-90deg, var(--theme-bg), transparent);
+      margin-left: auto;
+    }
   }
 }


### PR DESCRIPTION
Fixes an issue where the breadcrumb label's gradient background would overlap with media. This change hides the right-side gradient on breakpoints above `mid-break`.

**Before:**
![Screenshot 2024-01-16 at 1 36 37 PM](https://github.com/payloadcms/website/assets/89618855/cda92f78-e623-4c2a-bfbe-33f85d3b69b4)

**After:**
![Screenshot 2024-01-16 at 1 35 07 PM](https://github.com/payloadcms/website/assets/89618855/8b1dff29-951d-49e6-9526-e59282a965ae)
