### PR TITLE
chore:update vscode settings for deprecated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,9 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
+      "source.fixAll": "explicit"
     },
     "editor.formatOnSave": true,
   },
+  "cssrem.rootFontSize": 20,
 }


### PR DESCRIPTION
```
Controls whether auto fix action should be run on file save.

true: Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of "explicit".
```