### PR TITLE
chore: replace calc() expressions with rem units.

### DIFF
--- a/src/adapters/AlgoliaPagination/index.module.scss
+++ b/src/adapters/AlgoliaPagination/index.module.scss
@@ -3,14 +3,14 @@
 .pagination {
   display: flex;
   align-items: center;
-  margin-top: calc(var(--base) * 4);
+  margin-top: 4rem;
 
   &>*:not(:last-child) {
-    margin-right: calc(var(--base) * 0.25);
+    margin-right: 0.25rem;
   }
 
   @include small-break {
-    margin-top: calc(var(--base) * 3);
+    margin-top: 3rem;
   }
 }
 
@@ -22,14 +22,14 @@
 .paginationButton {
   all: unset;
   cursor: pointer;
-  width: calc(var(--base) * 4);
-  height: calc(var(--base) * 4);
+  width: 4rem;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 1px solid;
   border-color: transparent;
-  margin-right: calc(var(--base) * 0.5);
+  margin-right: 0.5rem;
   position: relative;
 
   &:hover {
@@ -45,14 +45,14 @@
   }
 
   @include small-break {
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
-    margin-right: calc(var(--base) * 0.25);
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0.25rem;
   }
 }
 
 .dash {
-  margin-right: calc(var(--base) * 0.5);
+  margin-right: 0.5rem;
 }
 
 .disabled {
@@ -95,14 +95,14 @@
 
 .nextPrev {
   display: flex;
-  margin-left: calc(var(--base) * 0.5);
+  margin-left: 0.5rem;
 }
 
 .chevronButton {
   all: unset;
   cursor: pointer;
-  width: calc(var(--base) * 4);
-  height: calc(var(--base) * 4);
+  width: 4rem;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -110,8 +110,8 @@
   border-color: transparent;
 
   svg {
-    width: var(--base);
-    height: var(--base);
+    width: 1rem;
+    height: 1rem;
   }
 
   &:hover {
@@ -136,7 +136,7 @@
   }
 
   @include small-break {
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
+    width: 2rem;
+    height: 2rem;
   }
 }

--- a/src/app/(cloud)/cloud/(tabs)/page.module.scss
+++ b/src/app/(cloud)/cloud/(tabs)/page.module.scss
@@ -5,20 +5,20 @@
 }
 
 .tabs {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }
 
 .controls {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     display: flex;
     align-items: flex-end;
     position: relative;
-    padding: calc(var(--base) * 2)  0;
-    gap: var(--base);
+    padding: 2rem  0;
+    gap: 1rem;
 
     @include mid-break {
-        margin-bottom: var(--base);
-        padding: calc(var(--base) * 1.5) 0;
+        margin-bottom: 1rem;
+        padding: 1.5rem 0;
         flex-wrap: wrap;
     }
 }
@@ -47,10 +47,10 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: calc(100% + calc(var(--base) * 4));
+    width: calc(100% + 4rem);
     height: 100%;
-    left: calc(var(--base) * -2);
-    right: calc(var(--base) * -2);
+    left: -2rem;
+    right: -2rem;
     background-color: var(--theme-elevation-100);
 
     @include mid-break {
@@ -61,7 +61,7 @@
 }
 
 .pagination {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
 }
 
 :global([data-theme="light"]) {

--- a/src/app/(cloud)/cloud/(tabs)/settings/DeletionConfirmationForm/page.module.scss
+++ b/src/app/(cloud)/cloud/(tabs)/settings/DeletionConfirmationForm/page.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common.scss' as *;
 
 .warning, .emailInput {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
 }
 
 .modal {
@@ -14,12 +14,12 @@
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: calc(var(--base)*2);
+  padding-top: 2rem;
   border-top: 1px solid var(--theme-border-color);
-  margin-top: calc(var(--base)*2);
+  margin-top: 2rem;
 
 }
 
@@ -30,7 +30,7 @@
 
     .modal {
         & > * {
-            padding: calc(var(--base)*2) var(--gutter-h);
+            padding: 2rem var(--gutter-h);
             border: 0;
         }
     }

--- a/src/app/(cloud)/cloud/(tabs)/settings/layout.module.scss
+++ b/src/app/(cloud)/cloud/(tabs)/settings/layout.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common.scss' as *;
 
 .gridWrap {
-  margin-bottom: calc(var(--base) * 4);
+  margin-bottom: 4rem;
 }
 
 .sidebarNav {
@@ -11,7 +11,7 @@
   top: var(--page-padding-top);
 
   @include small-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
     flex-direction: row;
   }
 }
@@ -19,8 +19,8 @@
 .sidebarNavItem {
   margin: 0;
   color: var(--theme-elevation-300);
-  margin-right: calc(var(--base) * .75);
-  margin-bottom: calc(var(--base) * 0.25);
+  margin-right: 0.75rem;
+  margin-bottom: 0.25rem;
 
   &.lastItem {
     margin-right: 0;

--- a/src/app/(cloud)/cloud/(tabs)/settings/page.module.scss
+++ b/src/app/(cloud)/cloud/(tabs)/settings/page.module.scss
@@ -2,7 +2,7 @@
 
 .buttonWrap {
     display: flex;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .form {
@@ -11,7 +11,7 @@
 }
 
 .description {
-    margin: var(--base) 0;
+    margin: 1rem 0;
 }
 
 .password {
@@ -41,7 +41,7 @@
 
 .form {
     & > * {
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
     }
 
     & > *:last-child {

--- a/src/app/(cloud)/cloud/(tabs)/teams/page.module.scss
+++ b/src/app/(cloud)/cloud/(tabs)/teams/page.module.scss
@@ -2,10 +2,10 @@
 
 .introContent {
   border-bottom: 1px solid var(--theme-border-color);
-  padding-bottom: calc(var(--base) * 2);
+  padding-bottom: 2rem;
 
   @include small-break {
-    padding-bottom: calc(var(--base) * 1.5);
+    padding-bottom: 1.5rem;
   }
 
   > * {
@@ -14,10 +14,10 @@
 }
 
 .linkGrid {
-  margin-bottom: calc(var(--base) * 2.5);
+  margin-bottom: 2.5rem;
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -34,7 +34,7 @@
   color: inherit;
   text-decoration: underline;
   color: var(--theme-blue-500);
-  
+
   &:focus-visible {
     @include outline;
   }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/page.module.scss
@@ -5,23 +5,23 @@
 }
 
 .tabs {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }
 
 .controls {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     display: flex;
     align-items: flex-end;
     position: relative;
-    padding: calc(var(--base) * 2)  0;
+    padding: 2rem  0;
 
     & > *:not(:last-child) {
-        margin-right: var(--base);
+        margin-right: 1rem;
     }
 
     @include mid-break {
-        margin-bottom: var(--base);
-        padding: calc(var(--base) * 1.5) 0;
+        margin-bottom: 1rem;
+        padding: 1.5rem 0;
         flex-wrap: wrap;
 
         & > * {
@@ -29,7 +29,7 @@
 
             &:not(:last-child) {
                 margin-right: 0;
-                margin-bottom: var(--base);
+                margin-bottom: 1rem;
             }
         }
     }
@@ -47,10 +47,10 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: calc(100% + calc(var(--base) * 4));
+    width: calc(100% + 4rem);
     height: 100%;
-    left: calc(var(--base) * -2);
-    right: calc(var(--base) * -2);
+    left: -2rem;
+    right: -2rem;
     background-color: var(--theme-elevation-50);
 
     @include mid-break {
@@ -62,9 +62,9 @@
 
 .description {
     position: relative;
-    margin: 0 0 calc(var(--base) * 2) 0;
+    margin: 0 0 2rem 0;
 }
 
 .pagination {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/billing/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/billing/page.module.scss
@@ -9,12 +9,12 @@
 }
 
 .fields {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 
   @include mid-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/invoices/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/invoices/page.module.scss
@@ -11,33 +11,33 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   list-style: none;
   padding: 0;
 }
 
 .invoice {
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   flex-direction: column;
-  
+
   &:not(:last-child) {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     border-bottom: 1px solid var(--theme-border-color);
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 
   @include small-break {
     &:not(:last-child) {
-      margin-bottom: var(--base);
-      padding-bottom: var(--base);
+      margin-bottom: 1rem;
+      padding-bottom: 1rem;
     }
   }
 }
 
 .invoiceTitle {
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   align-items: center;
 }
 
@@ -49,13 +49,13 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .invoiceContent {
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   flex-direction: column;
 }
 
@@ -75,5 +75,5 @@
 }
 
 .loadMore {
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/members/UpdateRolesConfirmationForm/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/members/UpdateRolesConfirmationForm/page.module.scss
@@ -10,12 +10,12 @@
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: calc(var(--base)*2);
+  padding-top: 2rem;
   border-top: 1px solid var(--theme-border-color);
-  margin-top: calc(var(--base)*2);
+  margin-top: 2rem;
 
 }
 
@@ -26,7 +26,7 @@
 
     .modal {
         & > * {
-            padding: calc(var(--base)*2) var(--gutter-h);
+            padding: 2rem var(--gutter-h);
             border: 0;
         }
     }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/members/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/members/page.module.scss
@@ -11,10 +11,10 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 
   @include mid-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }
 

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/subscriptions/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/(tabs)/subscriptions/page.module.scss
@@ -15,7 +15,7 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   list-style: none;
   padding: 0;
   margin: 0;
@@ -26,18 +26,18 @@
   align-items: flex-start;
 
   &:not(:last-child) {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     border-bottom: 1px solid var(--theme-border-color);
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 
   @include small-break {
     flex-direction: column;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
 
     &:not(:last-child) {
-      margin-bottom: var(--base);
-      padding-bottom: var(--base);
+      margin-bottom: 1rem;
+      padding-bottom: 1rem;
     }
   }
 }
@@ -48,19 +48,19 @@
 
 .subscriptionTitleWrapper {
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   align-items: center;
 
   @include small-break {
     flex-direction: column;
     align-items: flex-start;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
   }
 }
 
 .subscriptionTitle {
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   align-items: center;
   flex-grow: 1;
   flex-wrap: wrap;
@@ -70,7 +70,7 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .subscriptionCancel {
@@ -78,21 +78,21 @@
 }
 
 .subscriptionContent {
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   flex-direction: column;
 }
 
 .loadMore {
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
 }
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/TeamBillingMessages/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/TeamBillingMessages/index.module.scss
@@ -1,9 +1,9 @@
 @use '@scss/common.scss' as *;
 
 .billingMessages {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 
     @include mid-break {
-      margin-bottom: var(--base);
+      margin-bottom: 1rem;
     }
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/layout.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/layout.module.scss
@@ -1,5 +1,5 @@
 @use '@scss/common.scss' as *;
 
 .gridWrap {
-  margin-bottom: calc(var(--base) * 4);
+  margin-bottom: 4rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/(tabs)/settings/page.module.scss
@@ -8,9 +8,9 @@
     color: var(--theme-success-500);
 }
 
-.form {    
+.form {
     & > * {
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
     }
 
     & > *:last-child {
@@ -19,5 +19,5 @@
 }
 
 .hr {
-    margin: calc(var(--base) * 2) 0;
-}   
+    margin: 2rem 0;
+}

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/DeploymentLogs/index.module.scss
@@ -1,5 +1,5 @@
 .deploymentLogs {
-  margin-top: calc(var(--base) * 4);
+  margin-top: 4rem;
   isolation: isolate;
 
   .logTabs {
@@ -35,9 +35,9 @@
 .tabLabel {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * .75);
+  gap: 0.75rem;
 }
 
 .inactiveIndicator {
-  opacity: .25;
+  opacity: 0.25;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/InfraOffline/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/InfraOffline/index.module.scss
@@ -2,10 +2,10 @@
 
 .reTriggerBackground {
   display: flex;
-  gap: calc(var(--base) * 1.5);
+  gap: 1.5rem;
 
   @include small-break {
-    gap: var(--base);
+    gap: 1rem;
     flex-direction: column-reverse;
   }
 }
@@ -13,7 +13,7 @@
 .deployDetails {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
 
   p {
     margin: 0;
@@ -28,7 +28,7 @@
     svg {
       color: var(--theme-elevation-400);
       height: 20px;
-      margin-right: calc(var(--base) * 0.5);
+      margin-right: 0.5rem;
     }
   }
 }
@@ -36,7 +36,7 @@
 .indicationLine {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
 
   p {
     margin: 0;
@@ -47,10 +47,10 @@
 .statusLine {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
 
   p {
-    font-size: calc(var(--base) * .75);
+    font-size: 0.75rem;
     margin: 0;
     color: var(--theme-elevation-450);
 
@@ -124,7 +124,7 @@
 }
 
 .consoleHeading {
-  padding-top: calc(var(--base) * 2);
+  padding-top: 2rem;
 }
 
 .console {
@@ -155,19 +155,19 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 2);
+  gap: 2rem;
 
   @include mid-break {
-    gap: var(--base);
+    gap: 1rem;
   }
 }
 
 .indication {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 
   @include small-break {
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
   }
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/InfraOnline/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/(overview)/InfraOnline/index.module.scss
@@ -2,10 +2,10 @@
 
 .reTriggerBackground {
   display: flex;
-  gap: calc(var(--base) * 1.5);
+  gap: 1.5rem;
 
   @include small-break {
-    gap: var(--base);
+    gap: 1rem;
     flex-direction: column-reverse;
   }
 }
@@ -17,20 +17,20 @@
 .deployDetails {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
   justify-content: center;
-  
+
   p {
     margin: 0;
   }
-  
+
   .iconAndLabel {
     @include small;
     line-height: 16px;
     display: flex;
     align-items: center;
     color: var(--theme-elevation-500);
-    gap: calc(var(--base) * 0.5);
+    gap: 0.5rem;
 
     svg {
       color: var(--theme-elevation-400);
@@ -45,7 +45,7 @@
   }
 
   .deploymentIndicator {
-    gap: calc((var(--base) * 0.5) + 5px);
+    gap: calc(.5rem + 5px);
   }
 }
 
@@ -74,13 +74,13 @@
 
 .externalLinkIcon {
   flex-shrink: 0;
-  margin-left: calc(var(--base) / 2);
+  margin-left: 0.5rem;
 }
 
 .statusDetail {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
 
   .statusIndicator {
     border-radius: 100%;
@@ -99,7 +99,7 @@
 }
 
 .consoleHeading {
-  padding-top: calc(var(--base) * 2);
+  padding-top: 2rem;
 }
 
 .console {

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/ProjectBillingMessages/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/ProjectBillingMessages/index.module.scss
@@ -1,5 +1,5 @@
 @use '@scss/common.scss' as *;
 
 .billingMessages {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/file-storage/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/file-storage/page.module.scss
@@ -3,14 +3,14 @@
 .fields {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 }
 
 .meta {
   list-style: none;
   padding: 0;
   overflow-wrap: anywhere;
-  
+
   li {
     display: flex;
   }
@@ -21,11 +21,11 @@
 
     @include small-break {
       width: 50%;
-      padding-right: var(--base);
+      padding-right: 1rem;
     }
   }
 }
 
 .secretInput {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/(build-settings)/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/(build-settings)/page.module.scss
@@ -1,7 +1,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 
   button[type="submit"] {
     width: auto;

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/_layoutComponents/NoData/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/_layoutComponents/NoData/index.module.scss
@@ -1,5 +1,5 @@
 .noData {
-  padding: var(--base);
+  padding: 1rem;
   background-color: var(--theme-elevation-50);
   border: 1px solid var(--theme-border-color);
   margin: 0;

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/_layoutComponents/SectionHeader/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/_layoutComponents/SectionHeader/index.module.scss
@@ -1,5 +1,5 @@
 .sectionHeader {
-  margin-bottom: calc(var(--base) * 1.75);
+  margin-bottom: 1.75rem;
 }
 
 .titleAndLink {
@@ -10,7 +10,7 @@
 }
 
 .intro {
-  margin-top: calc(var(--base) * .25);
+  margin-top: 0.25rem;
   display: block;
   color: var(--theme-elevation-450)
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/billing/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/billing/page.module.scss
@@ -11,5 +11,5 @@
 .fields {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/domains/AddDomain/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/domains/AddDomain/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .formContent {
-  gap: var(--base);
+  gap: 1rem;
   display: flex;
   flex-direction: column;
 }
@@ -9,8 +9,8 @@
 .actionFooter {
   display: flex;
   justify-content: flex-end;
-  gap: var(--base);
-  margin-top: var(--base);
-  padding-top: var(--base);
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/domains/ManageDomain/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/domains/ManageDomain/index.module.scss
@@ -28,7 +28,7 @@
 }
 
 .domainInput {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 }
 
 .domainTitleName {
@@ -38,11 +38,11 @@
 .record {
   width: 100%;
   background: var(--theme-elevation-100);
-  padding: var(--base);
+  padding: 1rem;
 
   th,
   td {
-    padding-right: calc(var(--base) * .5);
+    padding-right: 0.5rem;
     vertical-align: top;
   }
 
@@ -51,12 +51,12 @@
     font-weight: normal;
     font-family: var(--font-mono);
     text-align: left;
-    padding: calc(var(--base) * .25 ) calc(var(--base) * .5 );
+    padding: 0.25rem 0.5rem;
   }
 
   td {
     font-size: 18px;
-    padding: 0 calc(var(--base) * .5 );
+    padding: 0 0.5rem;
     white-space: nowrap;
     color: var(--theme-text);
   }
@@ -64,11 +64,11 @@
 
 .domainActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  margin-top: var(--base);
-  padding-top: var(--base);
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 
   .leftActions {
@@ -83,9 +83,9 @@
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/AddEmailDomain/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/AddEmailDomain/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .formContent {
-  gap: var(--base);
+  gap: 1rem;
   display: flex;
   flex-direction: column;
 }
@@ -9,8 +9,8 @@
 .actionFooter {
   display: flex;
   justify-content: flex-end;
-  gap: var(--base);
-  margin-top: var(--base);
-  padding-top: var(--base);
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/ManageEmailDomain/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/ManageEmailDomain/index.module.scss
@@ -28,7 +28,7 @@
 }
 
 .domainField {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
   pointer-events: none;
 }
 
@@ -37,13 +37,13 @@
 }
 
 .domainInfo > * {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 }
 
 .records {
   display: block;
   background: var(--theme-elevation-50);
-  padding: var(--base);
+  padding: 1rem;
   overflow: auto;
 
   th {
@@ -51,12 +51,12 @@
     font-weight: normal;
     font-family: var(--font-mono);
     text-align: left;
-    padding: calc(var(--base) * .25 ) calc(var(--base) * .5 );
+    padding: 0.25rem 0.5rem;
   }
 
   td {
     font-size: 18px;
-    padding: 0 calc(var(--base) * .5 );
+    padding: 0 0.5rem;
     white-space: nowrap;
     color: var(--theme-text);
 
@@ -68,7 +68,7 @@
     button {
       display: inline-block;
       vertical-align: middle;
-      margin-right: calc(var(--base) * .25 );
+      margin-right: 0.25rem;
 
       span {
         width: 0;
@@ -111,11 +111,11 @@
 
 .domainActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  margin-top: var(--base);
-  padding-top: var(--base);
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 
   .leftActions {
@@ -130,9 +130,9 @@
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/email/index.module.scss
@@ -2,5 +2,5 @@
 
 .codeWrap {
   min-height: unset;
-  font-size: calc(var(--base) * 0.75);
+  font-size: 0.75rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/AddEnvs/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/AddEnvs/index.module.scss
@@ -1,14 +1,14 @@
 @use '@scss/common' as *;
 
 .formContent {
-  gap: var(--base);
+  gap: 1rem;
   display: flex;
   flex-direction: column;
 }
 
 .newItemRow {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   align-items: center;
 
   .trashButton {
@@ -49,8 +49,8 @@
 .actionFooter {
   display: flex;
   justify-content: flex-end;
-  gap: var(--base);
-  padding-top: var(--base);
+  gap: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
@@ -59,7 +59,7 @@
 }
 
 .addAnotherButton {
-  margin-top: calc(var(--base) * 0.75);
+  margin-top: 0.75rem;
   padding: 0;
   color: var(--theme-elevation-850);
 

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/ManageEnvs/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/ManageEnvs/index.module.scss
@@ -3,7 +3,7 @@
 .accordionFormContent {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 
   textarea {
     max-height: 150px;
@@ -14,23 +14,23 @@
   width: 100%;
   display: flex;
   justify-content: flex-end;
-  gap: var(--base);
-  margin-top: var(--base);
-  padding-top: var(--base);
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
 .envs {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/environment-variables/page.module.scss
@@ -1,11 +1,11 @@
 @use '@scss/common.scss' as *;
 
 .header {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 }
 
 .description {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }
 
 .link {

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/layout.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/layout.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common.scss' as *;
 
 .gridWrap {
-  margin-bottom: calc(var(--base) * 4);
+  margin-bottom: 4rem;
 }
 
 .sidebarNav {
@@ -11,7 +11,7 @@
   top: var(--page-padding-top);
 
   @include small-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
     flex-direction: row;
   }
 }
@@ -19,8 +19,8 @@
 .sidebarNavItem {
   margin: 0;
   color: var(--theme-elevation-300);
-  margin-right: calc(var(--base) * .75);
-  margin-bottom: calc(var(--base) * 0.25);
+  margin-right: 0.75rem;
+  margin-bottom: 0.25rem;
 
   &.lastItem {
     margin-right: 0;

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/ownership/page.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/ownership/page.module.scss
@@ -1,21 +1,21 @@
 .teamSelect {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
-  padding: calc(var(--base) * 1.25) var(--base);
+  gap: 1rem;
+  padding: 1.25rem 1rem;
   border: 1px solid var(--theme-border-color);
 }
 
 .actionsFooter {
   display: flex;
   justify-content: flex-end;
-  gap: var(--base);
-  padding-top: var(--base);
+  gap: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
 .noAccess {
-  padding: calc(var(--base) * 1.25) var(--base);
+  padding: 1.25rem 1rem;
   color: var(--color-warning-500);
   background: var(--theme-warning-100);
   border-bottom: 1px solid var(--color-warning-500);

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/DeletePlanModal/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/DeletePlanModal/index.module.scss
@@ -1,9 +1,9 @@
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 1px solid var(--theme-border-color);
-  margin-top: var(--base);
+  margin-top: 1rem;
 }

--- a/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/index.module.scss
+++ b/src/app/(cloud)/cloud/[team-slug]/[project-slug]/(tabs)/settings/plan/index.module.scss
@@ -1,21 +1,21 @@
 .plan {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 3.5);
+  gap: 3.5rem;
 }
 
 .borderBox {
-  padding: calc(var(--base) * 1.25);
+  padding: 1.25rem;
   border: 1px solid var(--theme-border-color);
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
 }
 
 .highlightHeading {
   position: relative;
-  padding-bottom: calc(var(--base) * 1.5);
+  padding-bottom: 1.5rem;
   display: inline-flex;
 
   &:after {

--- a/src/app/(cloud)/cloud/_components/CloneOrDeployProgress/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/CloneOrDeployProgress/index.module.scss
@@ -2,7 +2,7 @@
 
 .deployProgress {
     color: var(--theme-elevation-400);
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
     background-color: var(--theme-elevation-100);
     position: relative;
     border: 0.5px solid var(--theme-border-color);
@@ -12,7 +12,7 @@
 
     @include mid-break {
         min-height: 300px;
-        padding: var(--base);
+        padding: 1rem;
     }
 }
 
@@ -23,7 +23,7 @@
 
 .active {
     color: var(--theme-text);
-    
+
     &:local() {
         .dots > div > div {
             animation: dots infinite;
@@ -51,12 +51,12 @@
 .icons {
     display: flex;
     align-items: center;
-    gap: var(--base);
-    margin-bottom: calc(var(--base));
+    gap: 1rem;
+    margin-bottom: 1rem;
 
     @include small-break {
-        gap: calc(var(--base) / 2);
-        margin-bottom: var(--base);
+        gap: 0.5rem;
+        margin-bottom: 1rem;
     }
 }
 
@@ -64,12 +64,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(var(--base) * 1.5);
-    height: calc(var(--base) * 1.5);
+    width: 1.5rem;
+    height: 1.5rem;
 
     @include small-break {
-        width: var(--base);
-        height: var(--base);
+        width: 1rem;
+        height: 1rem;
     }
 }
 

--- a/src/app/(cloud)/cloud/_components/ComparePlans/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/ComparePlans/index.module.scss
@@ -2,7 +2,7 @@
 
 .drawerToggle {
   display: flex;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   align-items: center;
   text-decoration: underline;
   cursor: pointer;
@@ -14,7 +14,7 @@
 
 .compareTable {
   display: flex;
-  gap: calc(var(--base) * 2);
+  gap: 2rem;
   width: 100%;
 
   @include mid-break {
@@ -30,13 +30,13 @@
 
 .pricingCard {
   aspect-ratio: unset;
-  min-height: calc(var(--base) * 15);
+  min-height: 15rem;
   cursor: pointer;
 
   @include small-break {
     aspect-ratio: unset;
     & > span {
-      padding: var(--base);
+      padding: 1rem;
     }
   }
 }
@@ -49,11 +49,11 @@
 
 .features {
   list-style: none;
-  margin: calc(var(--base) * 2.5) 0;
+  margin: 2.5rem 0;
   color: var(--color-base-100);
 
   .feature {
-    margin: var(--base) 0;
+    margin: 1rem 0;
     display: flex;
   }
 
@@ -64,9 +64,9 @@
     justify-content: center;
     border-radius: 100%;
     flex-shrink: 0;
-    width: calc(var(--base) * 1.5);
-    height: calc(var(--base) * 1.5);
-    margin-right: calc(var(--base) * 1.5);
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 1.5rem;
     justify-items: center;
   }
 

--- a/src/app/(cloud)/cloud/_components/CreditCardList/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/CreditCardList/index.module.scss
@@ -4,9 +4,9 @@
     position: relative;
 }
 
-.scrollRef { 
+.scrollRef {
     position: absolute;
-    top: calc(var(--base) * -6);
+    top: -6rem;
 }
 
 .error {
@@ -20,13 +20,13 @@
 .formState {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 
     > * {
         margin: 0;
 
         &:last-child {
-            margin-bottom: var(--base);
+            margin-bottom: 1rem;
         }
     }
 }
@@ -34,8 +34,8 @@
 .cardState {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
-    margin-bottom: calc(var(--base) / 2);
+    gap: 1rem;
+    margin-bottom: 0.5rem;
 
     > * {
         margin: 0;
@@ -45,10 +45,10 @@
 .cards {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
-    
+    gap: 1rem;
+
     @include mid-break {
-        gap: calc(var(--base) / 2);
+        gap: 0.5rem;
     }
 }
 
@@ -56,17 +56,17 @@
 .newCard {
     border: 0.5px solid;
     border-color: var(--theme-border-color);
-    padding: var(--base);
+    padding: 1rem;
     display: flex;
     align-items: center;
-    gap: var(--base);
+    gap: 1rem;
 
     > * {
         margin: 0;
     }
 
     @include mid-break {
-        padding: calc(var(--base) * .75);
+        padding: 0.75rem;
     }
 }
 
@@ -81,10 +81,10 @@
 
 .cardBrand {
     flex-grow: 1;
-    line-height: var(--base);
+    line-height: 1rem;
     display: flex;
     align-items: center;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
 }
 
 .deleteCard,
@@ -97,7 +97,7 @@
     font-size: inherit;
     font-family: inherit;
     outline: none;
-    
+
     &:hover {
         cursor: pointer;
         text-decoration: underline;
@@ -107,8 +107,8 @@
 .controls {
     display: flex;
     align-items: center;
-    margin-top: var(--base);
-    gap: var(--base);
+    margin-top: 1rem;
+    gap: 1rem;
 }
 
 .saveNewCard,
@@ -129,9 +129,9 @@
 
 .modalActions {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: flex-end;
   width: 100%;
-  padding-top: var(--base);
+  padding-top: 1rem;
   border-top: 0.5px solid var(--theme-border-color);
 }

--- a/src/app/(cloud)/cloud/_components/CreditCardSelector/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/CreditCardSelector/index.module.scss
@@ -4,9 +4,9 @@
     position: relative;
 }
 
-.scrollRef { 
+.scrollRef {
     position: absolute;
-    top: calc(var(--base) * -6);
+    top: -6rem;
 }
 
 .error {
@@ -20,36 +20,36 @@
 .cards {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 
     @include mid-break {
-        gap: calc(var(--base) / 2);
+        gap: 0.5rem;
     }
 }
 
 .cardBrand {
     flex-grow: 1;
-    line-height: var(--base);
+    line-height: 1rem;
     display: flex;
     align-items: center;
 }
 
 .default {
-    margin-left: var(--base);
+    margin-left: 1rem;
 }
 
 .notice {
     @include small;
     color: var(--theme-elevation-500);
     margin: 0;
-    margin-top: calc(var(--base) / 2);
+    margin-top: 0.5rem;
 }
 
 .controls {
     display: flex;
     align-items: center;
-    margin-top: var(--base);
-    gap: var(--base);
+    margin-top: 1rem;
+    gap: 1rem;
 }
 
 .deleteCard,

--- a/src/app/(cloud)/cloud/_components/DashboardBreadcrumbs/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/DashboardBreadcrumbs/index.module.scss
@@ -1,5 +1,5 @@
 @use '@scss/common' as *;
 
 .dashboardBreadcrumbs {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }

--- a/src/app/(cloud)/cloud/_components/InstallationSelector/components/MenuList/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/InstallationSelector/components/MenuList/index.module.scss
@@ -11,5 +11,5 @@
     text-align: left;
     line-height: inherit;
     font-size: inherit;
-    padding: calc(var(--base) / 2) var(--base);
+    padding: 0.5rem 1rem;
 }

--- a/src/app/(cloud)/cloud/_components/InstallationSelector/components/Option/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/InstallationSelector/components/Option/index.module.scss
@@ -10,9 +10,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(var(--base) * 1);
-    height: calc(var(--base) * 1);
-    margin-right: calc(var(--base) * 0.5);
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.5rem;
     flex-shrink: 0;
 }
 

--- a/src/app/(cloud)/cloud/_components/InstallationSelector/components/SingleValue/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/InstallationSelector/components/SingleValue/index.module.scss
@@ -10,9 +10,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(var(--base) * 1);
-    height: calc(var(--base) * 1);
-    margin-right: calc(var(--base) * 0.5);
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.5rem;
     flex-shrink: 0;
 }
 

--- a/src/app/(cloud)/cloud/_components/InstallationSelector/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/InstallationSelector/index.module.scss
@@ -2,7 +2,7 @@
 
 .description {
     @include small;
-    margin-top: calc(var(--base) / 2);
+    margin-top: 0.5rem;
     color: var(--theme-elevation-400);
     margin-bottom: 0;
 }

--- a/src/app/(cloud)/cloud/_components/InviteTeammates/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/InviteTeammates/index.module.scss
@@ -1,22 +1,22 @@
 @use "@scss/common" as *;
 
-.invites {  
-  margin-bottom: var(--base);
-  
+.invites {
+  margin-bottom: 1rem;
+
   & > *:not(:last-child) {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }
 
 .item {
   display: flex;
   position: relative;
-  left: calc(var(--base) * -0.5);
-  width: calc(100% + var(--base));
+  left: -.5rem;
+  width: calc(100% + 1rem);
 
   & > * {
     flex: 1;
-    margin: 0 calc(var(--base) / 2);
+    margin: 0 0.5rem;
   }
 }
 
@@ -28,16 +28,16 @@
 
 @include small-break {
   .fieldWrap {
-    padding: var(--base) 0;
+    padding: 1rem 0;
     position: relative;
 
     &:before {
       position: absolute;
       content: '';
       width: 1px;
-      height: calc(100% - calc(var(--base)*2));
-      top: var(--base);
-      left: calc(var(--base) * -1);
+      height: calc(100% - 2rem);
+      top: 1rem;
+      left: -1rem;
       background-color: var(--theme-border-color);
     }
 

--- a/src/app/(cloud)/cloud/_components/PlanSelector/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/PlanSelector/index.module.scss
@@ -2,7 +2,7 @@
 
 .plans {
     & > *:not(:last-child) {
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
     }
 
     .plan {

--- a/src/app/(cloud)/cloud/_components/ProjectCard/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/ProjectCard/index.module.scss
@@ -13,7 +13,7 @@
     aspect-ratio: 1/1;
     display: flex;
     flex-direction: column;
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
     border: 0.5px solid;
     // no border for the default card until hover, match background color
     border-color: var(--border-color);
@@ -35,7 +35,7 @@
         }
 
         // turn off hover effects on mobile
-        @include mid-break {    
+        @include mid-break {
             border-color: var(--border-color);
 
             &:local() {
@@ -47,7 +47,7 @@
     }
 
     @include mid-break {
-        padding: var(--base);
+        padding: 1rem;
     }
 }
 
@@ -94,29 +94,29 @@
 
 .pills {
     display: flex;
-    gap: calc(var(--base) / 4);
-    margin-bottom: calc(var(--base) / 2);
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
 }
 
 .leader {
     @include label;
-    margin-bottom: calc(var(--base) / 2);
+    margin-bottom: 0.5rem;
 }
 
 .titleWrapper {
-    margin-bottom: calc(var(--base) / 2);
+    margin-bottom: 0.5rem;
 }
 
 .title {
     margin: 0;
-    padding-right: calc(var(--base) * 2);
+    padding-right: 2rem;
 
     @include mid-break {
         padding-right: 0;
     }
 
     @include small-break {
-        margin-bottom: calc(var(--base) * 0.5);
+        margin-bottom: 0.5rem;
     }
 }
 
@@ -136,13 +136,13 @@
     @include small-break {
         display: block;
         width: fit-content;
-        margin-bottom: calc(var(--base) * 0.25);
+        margin-bottom: 0.25rem;
     }
 }
 
 .projectName {
     @include h5;
-    margin-right: calc(var(--base) / 2);
+    margin-right: 0.5rem;
 }
 
 .teamName {
@@ -151,14 +151,14 @@
     & > p {
         margin: 0;
         white-space: nowrap;
-        overflow: hidden;   
+        overflow: hidden;
         text-overflow: ellipsis;
     }
 }
 
 .details {
     color: var(--secondary-text-color);
-    margin-top: calc(var(--base) / 2);
+    margin-top: 0.5rem;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
@@ -168,7 +168,7 @@
 .projectBranch,
 .projectRepo {
     display: flex;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
     align-items: center;
 
     p {
@@ -193,8 +193,8 @@
     color: var(--icon-color);
     opacity: 0;
     position: absolute;
-    top: calc(var(--base) * 2);
-    right: calc(var(--base) * 2);
-    width: var(--base);
-    height: var(--base);
+    top: 2rem;
+    right: 2rem;
+    width: 1rem;
+    height: 1rem;
 }

--- a/src/app/(cloud)/cloud/_components/RadioGroup/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/RadioGroup/index.module.scss
@@ -3,21 +3,21 @@
 .radioCards {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
-  margin-bottom: var(--base);
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 
 .radioCard {
   position: relative;
-  padding: calc(var(--base) * .75);
+  padding: 0.75rem;
   border: 1px solid var(--theme-border-color);
   display: flex;
   align-items: center;
-  gap: var(--base);
+  gap: 1rem;
   color: var(--theme-elevation-550);
   background-color: var(--theme-elevation-150);
   cursor: pointer;
-  
+
   .styledRadioInput {
     &:after {
       opacity: 0;
@@ -36,7 +36,7 @@
     color: var(--theme-success-500);
     border-color: var(--theme-success-500);
     background-color: var(--theme-success-50);
-  
+
     .styledRadioInput {
       background: var(--theme-success-100);
       &:after {
@@ -98,7 +98,7 @@
       border-color: var(--theme-success-550);
       color: var(--color-success-850);
       background-color: var(--theme-success-450);
-    
+
       .styledRadioInput {
         background: var(--theme-success-600);
         &:after {
@@ -106,11 +106,11 @@
         }
       }
     }
-  
+
     &:checked:focus-visible + .radioCard {
       border-color: var(--theme-success-650);
     }
-  
+
     &:not(:active):not(:checked):focus-visible + .radioCard,
     &:not(:active):not(:checked) + .radioCard:hover {
       color: var(--theme-elevation-550);

--- a/src/app/(cloud)/cloud/_components/RepoExists/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/RepoExists/index.module.scss
@@ -3,7 +3,7 @@
 .uniqueRepoName {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .error {

--- a/src/app/(cloud)/cloud/_components/Sidebar/layout.module.scss
+++ b/src/app/(cloud)/cloud/_components/Sidebar/layout.module.scss
@@ -7,7 +7,7 @@
   top: var(--page-padding-top);
 
   @include small-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
     flex-direction: row;
   }
 }
@@ -15,8 +15,8 @@
 .sidebarNavItem {
   margin: 0;
   color: var(--theme-elevation-300);
-  margin-right: calc(var(--base) * .75);
-  margin-bottom: calc(var(--base) * 0.25);
+  margin-right: 0.75rem;
+  margin-bottom: 0.25rem;
 
   &.lastItem {
     margin-right: 0;

--- a/src/app/(cloud)/cloud/_components/Tabs/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/Tabs/index.module.scss
@@ -3,7 +3,7 @@
 .tabsContainer {
   position: relative;
   width: 100%;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   &:after {
     // thin full width line
@@ -17,7 +17,7 @@
   }
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -29,13 +29,13 @@
   text-decoration: none;
   white-space: nowrap;
   margin: 0;
-  margin-right: calc(var(--base) * 1.5);
-  padding-bottom: calc(var(--base) * 1.5);
+  margin-right: 1.5rem;
+  padding-bottom: 1.5rem;
   position: relative;
   color: var(--theme-elevation-300);
   display: flex;
   align-items: center;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   cursor: pointer;
 
   &.lastTab {
@@ -69,12 +69,12 @@
     &.warning {
       color: var(--theme-warning-500);
     }
-    
+
     &.error {
       color: var(--theme-error-500);
     }
   }
-  
+
   &.warning {
     color: var(--theme-warning-300);
   }
@@ -94,8 +94,8 @@
   top: 2px;
   border: 1px solid currentColor;
   border-radius: 50%;
-  width: calc(var(--base) * 1.25);
-  height: calc(var(--base) * 1.25);
+  width: 1.25rem;
+  height: 1.25rem;
   flex-shrink: 0;
 }
 
@@ -107,9 +107,9 @@
 }
 
 .tabsContainer {
-  @include mid-break {    
+  @include mid-break {
     .tab {
-      padding-bottom: calc(var(--base));
+      padding-bottom: 1rem;
     }
   }
 }

--- a/src/app/(cloud)/cloud/_components/TeamDrawer/DrawerContent.module.scss
+++ b/src/app/(cloud)/cloud/_components/TeamDrawer/DrawerContent.module.scss
@@ -3,7 +3,7 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 }
 
 .error {

--- a/src/app/(cloud)/cloud/_components/TeamInvitations/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/TeamInvitations/index.module.scss
@@ -3,7 +3,7 @@
 .invitations {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .success {
@@ -30,7 +30,7 @@
 .formState {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 
   & > * {
       margin: 0;

--- a/src/app/(cloud)/cloud/_components/TeamMembers/TeamMemberRow.module.scss
+++ b/src/app/(cloud)/cloud/_components/TeamMembers/TeamMemberRow.module.scss
@@ -2,12 +2,12 @@
 
 .leader {
   margin-top: 0;
-  margin-bottom: calc(var(--base) / 4);
+  margin-bottom: 0.25rem;
 }
 
 .memberFields {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
 
   & > * {
       flex: 1;
@@ -28,7 +28,7 @@
 
 .footer {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   color: var(--theme-elevation-500);
 
    > a, button {

--- a/src/app/(cloud)/cloud/_components/TeamMembers/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/TeamMembers/index.module.scss
@@ -3,7 +3,7 @@
 .members {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .success {

--- a/src/app/(cloud)/cloud/_components/TeamSelector/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/TeamSelector/index.module.scss
@@ -32,5 +32,5 @@
     font-size: inherit;
     font-family: inherit;
     font-size: inherit;
-    padding: calc(var(--base) / 2) var(--base);
+    padding: 0.5rem 1rem;
 }

--- a/src/app/(cloud)/cloud/_components/UniqueDomain/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/UniqueDomain/index.module.scss
@@ -15,7 +15,7 @@
 
 .description {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
 }
 
 .check {

--- a/src/app/(cloud)/cloud/_components/UniqueRepoName/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/UniqueRepoName/index.module.scss
@@ -3,7 +3,7 @@
 .uniqueRepoName {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .error {

--- a/src/app/(cloud)/cloud/_components/UniqueSlug/index.module.scss
+++ b/src/app/(cloud)/cloud/_components/UniqueSlug/index.module.scss
@@ -15,7 +15,7 @@
 
 .description {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
 }
 
 .check {

--- a/src/app/(cloud)/forgot-password/page.module.scss
+++ b/src/app/(cloud)/forgot-password/page.module.scss
@@ -2,15 +2,15 @@
 @use "../../../forms/fields/shared.scss";
 
 .submit {
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include mid-break {
-    margin-top: calc(var(--base) / 4);
+    margin-top: 0.25rem;
   }
 }
 
 .links {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   & > * {
     margin: 0;
@@ -25,16 +25,16 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
 
   @include mid-break {
-    gap: calc(var(--base) * 1);
+    gap: 1rem;
   }
 }
 
 .buttonWrap {
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
   display: flex;
   align-items: center;
-  gap: var(--base);
+  gap: 1rem;
 }

--- a/src/app/(cloud)/layout.module.scss
+++ b/src/app/(cloud)/layout.module.scss
@@ -1,10 +1,10 @@
 @use '@scss/common' as *;
 
 .layout {
-  padding-top: calc(var(--page-padding-top) + var(--base) * 2);
-  padding-bottom: calc(var(--base) * 8);
+  padding-top: calc(var(--page-padding-top) + 2rem);
+  padding-bottom: 8rem;
 
   @include mid-break {
-    padding-bottom: calc(var(--base) * 4);
+    padding-bottom: 4rem;
   }
 }

--- a/src/app/(cloud)/login/page.module.scss
+++ b/src/app/(cloud)/login/page.module.scss
@@ -2,28 +2,28 @@
 @use "../../../forms/fields/shared.scss";
 
 .submit {
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include mid-break {
-    margin-top: calc(var(--base) / 4);
+    margin-top: 0.25rem;
   }
 }
 
 .sidebarWrap {
   @include mid-break {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
   }
 
   @include small-break {
-    margin-top: calc(var(--base) * 1);
+    margin-top: 1rem;
   }
 }
 
 .sidebar {
   display: flex;
   flex-direction: column;
-  margin-top: var(--base);
-  gap: calc(var(--base) * .5);
+  margin-top: 1rem;
+  gap: 0.5rem;
 
   & a {
     color: var(--theme-blue-500);
@@ -42,9 +42,9 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
 
   @include mid-break {
-    gap: calc(var(--base) * 1);
+    gap: 1rem;
   }
 }

--- a/src/app/(cloud)/logout/page.module.scss
+++ b/src/app/(cloud)/logout/page.module.scss
@@ -2,10 +2,10 @@
 
 .controls {
   display: flex;
-  gap: var(--base);
-  margin-top: var(--base);
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
 .content {
-  margin-top: calc(var(--base));
+  margin-top: 1rem;
 }

--- a/src/app/(cloud)/new/(checkout)/Checkout.module.scss
+++ b/src/app/(cloud)/new/(checkout)/Checkout.module.scss
@@ -2,22 +2,22 @@
 @use "../../../../forms/fields/shared.scss";
 
 .header {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }
 
 .formState {
     & > * {
         margin: 0;
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
 
         &:last-child {
-            margin-bottom: calc(var(--base) * 2);
+            margin-bottom: 2rem;
         }
     }
 
     @include mid-break {
         & > * {
-            margin-bottom: calc(var(--base) / 2);
+            margin-bottom: 0.5rem;
         }
     }
 }
@@ -27,22 +27,22 @@
 }
 
 .submit {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
     display: flex;
     align-items: center;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .submitDescription {
     margin: 0;
     color: var(--theme-elevation-500);
-    margin-top: var(--base);
+    margin-top: 1rem;
 }
 
 .fields {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .sidebarCell {
@@ -53,13 +53,13 @@
 .sidebar {
     position: sticky;
     top: var(--page-padding-top);
-    gap: var(--base);
+    gap: 1rem;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
 
     @include mid-break {
-        gap: calc(var(--base) / 2);
+        gap: 0.5rem;
         position: static;
         top: unset;
     }
@@ -87,7 +87,7 @@
 }
 
 .freeTrial {
-    margin-top: var(--base);
+    margin-top: 1rem;
 }
 
 .freeTrialDisabled {
@@ -95,7 +95,7 @@
 }
 
 .plansSection {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }
 
 .plansSectionHeader {
@@ -107,19 +107,19 @@
 .projectDetails {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .buildSettings {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .paymentInformation {
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 }
 
 .paymentInformationDescription {
@@ -138,7 +138,7 @@
 }
 
 .agreeToTerms {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
 
     a {
         color: var(--theme-blue-500);
@@ -154,6 +154,6 @@
   }
 
   @include mid-break {
-    margin: var(--base) 0;
+    margin: 1rem 0;
   }
 }

--- a/src/app/(cloud)/new/(checkout)/EnvVars.module.scss
+++ b/src/app/(cloud)/new/(checkout)/EnvVars.module.scss
@@ -1,10 +1,10 @@
 @use "@scss/common" as *;
 
-.vars {  
-  margin-bottom: var(--base);
+.vars {
+  margin-bottom: 1rem;
 
   & > *:not(:last-child) {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }
 
@@ -15,12 +15,12 @@
 .fields {
   display: flex;
   position: relative;
-  left: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
-  width: calc(100% + calc(var(--base)));
+  left: -.5rem;
+  right: -.5rem;
+  width: calc(100% + 1rem);
 
   & > * {
-    margin: 0 calc(var(--base) / 2);
-    width: calc(50% - calc(var(--base) / 2));
+    margin: 0 0.5rem;
+    width: calc(50% - 0.5rem);
   }
 }

--- a/src/app/(cloud)/new/authorize/page.module.scss
+++ b/src/app/(cloud)/new/authorize/page.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .header {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }
 
 .ghLink {
@@ -11,7 +11,7 @@
     border: 0;
     border-top: 0.5px solid var(--theme-elevation-250);
     border-bottom: 0.5px solid var(--theme-elevation-250);
-    padding: calc(var(--base) * 2) 0;
+    padding: 2rem 0;
     background: transparent;
     outline: none;
     text-align: left;
@@ -23,13 +23,13 @@
 }
 
 .ghIcon {
-    margin-right: var(--base);
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
+    margin-right: 1rem;
+    width: 2rem;
+    height: 2rem;
 }
 
 .footer {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
 
     a {
         color: var(--theme-blue-500);

--- a/src/app/(cloud)/new/clone/[template-slug]/page.module.scss
+++ b/src/app/(cloud)/new/clone/[template-slug]/page.module.scss
@@ -4,16 +4,16 @@
 .formState {
     & > * {
         margin: 0;
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
 
         &:last-child {
-            margin-bottom: calc(var(--base) * 2);
+            margin-bottom: 2rem;
         }
     }
-    
+
     @include mid-break {
-        & > * {    
-            margin-bottom: calc(var(--base) / 2);
+        & > * {
+            margin-bottom: 0.5rem;
         }
     }
 }
@@ -28,12 +28,12 @@
     top: var(--page-padding-top);
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 
     @include mid-break {
         position: static;
         top: unset;
-        gap: var(--base);
+        gap: 1rem;
     }
 }
 
@@ -47,7 +47,7 @@
 }
 
 .noTeams {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     color: var(--theme-error-500);
 }
 
@@ -58,15 +58,15 @@
 }
 
 .templateIcon {
-    width: var(--base);
-    height: var(--base);
+    width: 1rem;
+    height: 1rem;
     position: relative;
     top: -1px;
 }
 
 .templateName {
     margin: 0;
-    margin-left: calc(var(--base) / 2);
+    margin-left: 0.5rem;
 }
 
 .createTeamLink {
@@ -86,7 +86,7 @@
 .wrapper {
     display: flex;
     flex-direction: column;
-    gap: calc(var(--base) * 2);
+    gap: 2rem;
 }
 
 .submit {
@@ -94,5 +94,5 @@
 }
 
 .breadcrumbsWrap {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 }

--- a/src/app/(cloud)/new/import/RepoCard/index.module.scss
+++ b/src/app/(cloud)/new/import/RepoCard/index.module.scss
@@ -10,11 +10,11 @@
 .repo {
     display: flex;
     align-items: center;
-    padding: calc(var(--base) * 2) 0;
+    padding: 2rem 0;
     position: relative;
 
     @include small-break {
-        padding: var(--base) 0;
+        padding: 1rem 0;
         flex-direction: column;
         align-items: flex-start;
     }
@@ -30,7 +30,7 @@
 
 .repoContent {
     flex-grow: 1;
-    margin-right: var(--base);
+    margin-right: 1rem;
     // set a `height` so that cards with no description so not shift the layout
     // this is because description may or may not render depending on the data
     height: 75px;
@@ -38,12 +38,12 @@
     flex-direction: column;
     justify-content: center;
     overflow: hidden;
-    gap: calc(var(--base) / 4);
+    gap: 0.25rem;
 
     @include small-break {
         height: auto;
         margin-right: 0;
-        margin-bottom: calc(var(--base) / 2);
+        margin-bottom: 0.5rem;
     }
 }
 
@@ -54,7 +54,7 @@
 }
 
 .repoDescription {
-    margin-top: calc(var(--base) / 2);
+    margin-top: 0.5rem;
     color: var(--theme-elevation-500);
     overflow: hidden;
     width: 100%;

--- a/src/app/(cloud)/new/import/page.module.scss
+++ b/src/app/(cloud)/new/import/page.module.scss
@@ -15,36 +15,36 @@
 .sidebar {
     position: sticky;
     top: var(--page-padding-top);
-    gap: calc(var(--base) * 2);
+    gap: 2rem;
     display: flex;
     flex-direction: column;
-    gap: var(--base);
+    gap: 1rem;
 
     @include mid-break {
         position: static;
         top: unset;
-        gap: var(--base);
+        gap: 1rem;
     }
 }
 
 .noTeams {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     color: var(--theme-error-500);
 }
 
 .formState {
     & > * {
         margin: 0;
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
 
         &:last-child {
-            margin-bottom: calc(var(--base) * 2);
+            margin-bottom: 2rem;
         }
     }
-    
+
     @include mid-break {
-        & > * {    
-            margin-bottom: calc(var(--base) / 2);
+        & > * {
+            margin-bottom: 0.5rem;
         }
     }
 }
@@ -55,7 +55,7 @@
 
 .repos {
     border-top: 0.5px solid var(--theme-elevation-350);
-    
+
     > ul { gap: 0; }
 }
 
@@ -64,5 +64,5 @@
 }
 
 .pagination {
-    margin-top: calc(var(--base) * 3);
+    margin-top: 3rem;
 }

--- a/src/app/(cloud)/reset-password/page.module.scss
+++ b/src/app/(cloud)/reset-password/page.module.scss
@@ -2,19 +2,19 @@
 @use "../../../forms/fields/shared.scss";
 
 .submit {
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include mid-break {
-    margin-top: calc(var(--base) / 4);
+    margin-top: 0.25rem;
   }
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
 
   @include mid-break {
-    gap: calc(var(--base) * 1);
+    gap: 1rem;
   }
 }

--- a/src/app/(cloud)/signup/page.module.scss
+++ b/src/app/(cloud)/signup/page.module.scss
@@ -2,15 +2,15 @@
 @use "../../../forms/fields/shared.scss";
 
 .submit {
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include mid-break {
-    margin-top: calc(var(--base) / 4);
+    margin-top: 0.25rem;
   }
 }
 
 .links {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   & a {
     color: var(--theme-blue-500);
@@ -21,16 +21,16 @@
 .form {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
 
   @include mid-break {
-    gap: calc(var(--base) * 1);
+    gap: 1rem;
   }
 }
 
 .buttonWrap {
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
   display: flex;
   align-items: center;
-  gap: var(--base);
+  gap: 1rem;
 }

--- a/src/app/(pages)/blog/[slug]/AuthorsList/index.module.scss
+++ b/src/app/(pages)/blog/[slug]/AuthorsList/index.module.scss
@@ -3,7 +3,7 @@
 .authorSlot {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * .25);
+  gap: 0.25rem;
 
   @include mid-break {
     padding: 0;
@@ -26,7 +26,7 @@
 .author {
   display: flex;
   align-items: center;
-  padding: 0 0 calc(var(--base) * 0.5) 0;
+  padding: 0 0 0.5rem 0;
 
   span {
     color: var(--theme-elevation-900);
@@ -52,6 +52,6 @@
   height: 30px;
   border-radius: 100%;
   overflow: hidden;
-  margin-right: calc(var(--base) * 0.75);
+  margin-right: 0.75rem;
   flex-shrink: 0;
 }

--- a/src/app/(pages)/blog/[slug]/BlogPost/index.module.scss
+++ b/src/app/(pages)/blog/[slug]/BlogPost/index.module.scss
@@ -4,7 +4,7 @@
   border-bottom: 1px solid var(--grid-line-dark);
   position: relative;
   overflow: hidden;
-  padding-bottom: calc(var(--base) * 3);
+  padding-bottom: 3rem;
 
   @include data-theme-selector('dark') {
     border-color: var(--grid-line-dark);
@@ -16,7 +16,7 @@
 }
 
 .titleWrap {
-  padding: calc(var(--base) * 2.5) 0;
+  padding: 2.5rem 0;
 }
 
 .title {
@@ -39,7 +39,7 @@
 }
 
 .authorTimeSlots {
-  padding: calc(var(--base) * 2.5) var(--base);
+  padding: 2.5rem 1rem;
   border-bottom: 1px solid var(--grid-line-dark);
 
   @include data-theme-selector('dark') {
@@ -51,17 +51,17 @@
   }
 
   @include mid-break {
-    margin-top: var(--base);
+    margin-top: 1rem;
   }
 }
 
 .dateSlot {
-  padding: calc(var(--base) * 1.25) 0 0;
+  padding: 1.25rem 0 0;
   display: flex;
   flex-direction: column;
 
   @include mid-break {
-    padding: calc(var(--base) * .5) 0 0;
+    padding: 0.5rem 0 0;
   }
 }
 
@@ -88,10 +88,10 @@
 }
 
 .excerpt {
-  margin: calc(var(--base) * 2) 0;
+  margin: 2rem 0;
 
   @include mid-break {
-    margin: var(--base) 0;
+    margin: 1rem 0;
   }
 }
 
@@ -112,10 +112,10 @@
 .blocks {
   & > * {
     & > * {
-      margin-top: calc(var(--base) * 2);
+      margin-top: 2rem;
 
       &:last-child {
-        margin-bottom: calc(var(--base) * 2);
+        margin-bottom: 2rem;
       }
     }
   }
@@ -131,7 +131,7 @@
 
 @include mid-break {
   .mobileAuthor {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
     display: flex;
 
     > * {
@@ -150,12 +150,12 @@
   }
 
   .mobileAuthor {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
     display: flex;
     flex-direction: column;
   }
 
   .heroImage {
-    padding-bottom: calc(var(--base) * 1.5);
+    padding-bottom: 1.5rem;
   }
 }

--- a/src/app/(pages)/blog/index.module.scss
+++ b/src/app/(pages)/blog/index.module.scss
@@ -1,14 +1,14 @@
 @use '@scss/common' as *;
 
 .hero {
-  margin-bottom: calc(var(--base) * 5);
+  margin-bottom: 5rem;
 }
 
 .pageTitle {
   @include h5;
   opacity: 0.5;
   margin: 0;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 
@@ -17,7 +17,7 @@
   margin: 0;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 }
 
@@ -26,9 +26,9 @@
 }
 
 .cardGrid {
-  row-gap: calc(var(--base) * 5);
+  row-gap: 5rem;
 
   @include mid-break {
-    row-gap: calc(var(--base) * 2.5);
+    row-gap: 2.5rem;
   }
 }

--- a/src/app/(pages)/case-studies/[slug]/index.module.scss
+++ b/src/app/(pages)/case-studies/[slug]/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .featuredMediaWrap {
-  margin-top: calc(var(--base) * 4);
+  margin-top: 4rem;
   width: calc(100% + var(--gutter-h));
 
   img {
@@ -9,7 +9,7 @@
   }
 
   @include large-break {
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
     margin-left: 0;
     width: calc(100% + var(--gutter-h));
   }
@@ -18,13 +18,13 @@
 .metaWrapper {
   @include mid-break {
     display: flex;
-    margin-top: calc(var(--base) * 2);
+    margin-top: 2rem;
   }
 }
 
 .metaItem {
   border-top: 1px solid var(--grid-line-dark);
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
 
   @include data-theme-selector('dark') {
     border-color: var(--grid-line-dark);

--- a/src/app/(pages)/docs/[topic]/[doc]/index.module.scss
+++ b/src/app/(pages)/docs/[topic]/[doc]/index.module.scss
@@ -6,7 +6,7 @@
 }
 
 .content {
-  padding-top: calc(var(--base) * 2);
+  padding-top: 2rem;
   min-width: 0;
   line-height: 1.6;
 
@@ -17,7 +17,7 @@
 
 .mdx {
   @include color-links;
-  padding-bottom: calc(var(--base) * 2);
+  padding-bottom: 2rem;
 
   h2 {
     @include h3;
@@ -67,7 +67,7 @@
   top: var(--page-padding-top);
   max-height: calc(100vh - var(--page-padding-top));
   overflow: scroll;
-  padding: calc(var(--base) * 2) 0;
+  padding: 2rem 0;
 
   &::-webkit-scrollbar {
     background-color: transparent;
@@ -102,7 +102,7 @@
 .next {
   position: relative;
   display: block;
-  padding: calc(var(--base) * 3) 0;
+  padding: 3rem 0;
   text-decoration: none;
   border-top: 1px solid var(--theme-border-color);
   transition: all var(--trans-default) linear;
@@ -144,7 +144,7 @@
   }
 
   @include mid-break {
-    margin: 0 calc(var(--base)*-2)!important;
+    margin: 0 -2rem!important;
   }
 }
 
@@ -155,10 +155,10 @@
 .nextLabel {
   display: flex;
   align-items: center;
-  padding-bottom: calc(var(--base) * 0.5);
+  padding-bottom: 0.5rem;
 
   svg {
     transition: all var(--trans-default) linear;
-    margin-left: calc(var(--base) * .5);
+    margin-left: 0.5rem;
   }
 }

--- a/src/app/(pages)/docs/index.module.scss
+++ b/src/app/(pages)/docs/index.module.scss
@@ -28,7 +28,7 @@
   max-height: calc(100vh - var(--page-padding-top));
   overflow: auto;
   flex-shrink: 0;
-  padding: calc(var(--base) * 2) var(--base);
+  padding: 2rem 1rem;
 
   &::-webkit-scrollbar,  &::-webkit-scrollbar-thumb {
     background-color: transparent;
@@ -45,7 +45,7 @@
     left: 0;
     background: var(--theme-bg);
     width: auto;
-    padding: var(--gutter-h) var(--gutter-h) calc(var(--base) * 5);
+    padding: var(--gutter-h) var(--gutter-h) 5rem;
     overflow: auto;
     max-height: initial;
     margin-right: 0;
@@ -57,7 +57,7 @@
   left: 0;
   top: 0;
   transition: all var(--trans-default) ease-in-out;
-  height: calc(var(--base) * 1.3);
+  height: 1.3rem;
   background-color: var(--theme-elevation-800);
   width: 2px;
 }
@@ -66,8 +66,8 @@
   display: block;
   position: sticky;
   width: 100%;
-  height: calc(var(--base) * 4);
-  bottom: calc(var(--base) * -1.95);
+  height: 4rem;
+  bottom: -2rem;
   left: 0;
   background: linear-gradient(180deg, transparent 0%, var(--theme-bg) 100%);
   pointer-events: none;
@@ -85,7 +85,7 @@
   @include btnReset;
   display: none;
   position: fixed;
-  height: calc(var(--base) * 3);
+  height: 3rem;
   z-index: calc(var(--z-nav) + 2);
   bottom: 0;
   left: 0;
@@ -116,12 +116,12 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  margin-bottom: calc(var(--base) * .5);
+  margin-bottom: 0.5rem;
 
   .chevron {
     transition: all var(--trans-default) ease-in-out;
     opacity: 0;
-    margin-left: calc(var(--base) * .75);
+    margin-left: 0.75rem;
   }
 
   &--active {
@@ -139,8 +139,8 @@
   }
 
   @include mid-break {
-    font-size: var(--base);
-    margin-bottom: calc(var(--base) * .5);
+    font-size: 1rem;
+    margin-bottom: 0.5rem;
   }
 }
 
@@ -152,8 +152,8 @@
   list-style: none;
   color: var(--theme-elevation-600);
   text-decoration: none;
-  padding-left: var(--base);
-  margin-bottom: calc(var(--base) * .75);
+  padding-left: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .doc {
@@ -162,7 +162,7 @@
   display: inline-flex;
   position: relative;
   text-decoration: none;
-  margin-bottom: calc(var(--base) * .25);
+  margin-bottom: 0.25rem;
 
   &:hover {
     color: var(--theme-text);
@@ -179,7 +179,7 @@
   }
 
   @include mid-break {
-    font-size: var(--base);
-    margin-bottom: calc(var(--base) * .25);
+    font-size: 1rem;
+    margin-bottom: 0.25rem;
   }
 }

--- a/src/app/(pages)/privacy/page.module.scss
+++ b/src/app/(pages)/privacy/page.module.scss
@@ -18,5 +18,5 @@
 }
 
 .radioGroup {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 }

--- a/src/app/(pages)/styleguide/layout.module.scss
+++ b/src/app/(pages)/styleguide/layout.module.scss
@@ -1,3 +1,3 @@
 .layout {
-  padding-top: calc(var(--page-padding-top) + var(--base) * 2);
+  padding-top: calc(var(--page-padding-top) + 2rem);
 }

--- a/src/app/_components/Accordion/index.module.scss
+++ b/src/app/_components/Accordion/index.module.scss
@@ -15,7 +15,7 @@
   outline: none;
   border: none;
   background-color: var(--theme-elevation-50);
-  padding: calc(var(--base) * .5) calc(var(--base) * 1);
+  padding: 0.5rem 1rem;
   color: inherit;
   font-size: inherit;
   font-weight: inherit;
@@ -52,7 +52,7 @@
   font-size: 18px;
   margin: 0;
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   align-items: center;
 
   * {
@@ -73,7 +73,7 @@
   &:focus-visible {
     background-color: var(--theme-elevation-200);
   }
-  
+
   &:focus-visible {
     @include outline;
   }
@@ -96,6 +96,6 @@
 }
 
 .collapsibleContent {
-  padding: calc(var(--base) * 1);
+  padding: 1rem;
   border-top: 1px solid var(--theme-border-color);
 }

--- a/src/app/_components/BorderBox/index.module.scss
+++ b/src/app/_components/BorderBox/index.module.scss
@@ -1,10 +1,10 @@
 @use '@scss/common' as *;
 
 .borderBox {
-  padding: calc(var(--base) * 1.5);
-  border: 0.5px solid var(--theme-border-color); 
+  padding: 1.5rem;
+  border: 0.5px solid var(--theme-border-color);
 
   @include mid-break {
-    padding: calc(var(--base) * .75);
+    padding: 0.75rem;
   }
 }

--- a/src/app/_components/ExtendedBackground/index.module.scss
+++ b/src/app/_components/ExtendedBackground/index.module.scss
@@ -1,20 +1,20 @@
 @use '@scss/common.scss' as *;
 
 .container {
-  --bg-extension: calc(var(--gutter-h) * .5);
+  --bg-extension: calc(var(--gutter-h) * 0.5);
   --pixel-bg-extension: calc(var(--bg-extension) * 2);
   --pixel-padding: calc(var(--bg-extension) / 2);
   position: relative;
 
   @include large-break {
-    --bg-extension: calc(var(--gutter-h) * .75);
+    --bg-extension: calc(var(--gutter-h) * 0.75);
   }
 
   @include mid-break {
     --bg-extension: var(--gutter-h);
     --pixel-padding: var(--bg-extension);
   }
-  
+
   &.withPixels {
    padding-bottom: var(--pixel-padding);
   }
@@ -67,12 +67,12 @@
   left: 1px;
   inset: 1px;
   background-color: var(--theme-bg);
-  padding: calc(var(--base) * 1.5) calc(var(--bg-extension) / 2);
+  padding: 1.5rem calc(var(--bg-extension) / 2);
   margin-right: 2px;
   margin-bottom: 2px;
 
   @include small-break {
-    padding: calc(var(--base) * 1) calc(var(--bg-extension) / 2);
+    padding: 1rem calc(var(--bg-extension) / 2);
   }
 }
 

--- a/src/app/_components/HR/index.module.scss
+++ b/src/app/_components/HR/index.module.scss
@@ -1,17 +1,17 @@
 @use '@scss/common' as *;
 
 .hr {
-  margin: calc(var(--base) * 3) 0;
+  margin: 3rem 0;
 
   @include mid-break {
-      margin: calc(var(--base) * 2) 0;
+      margin: 2rem 0;
   }
 }
 
 .margin--small {
-  margin: var(--base) 0;
+  margin: 1rem 0;
 
   @include mid-break {
-      margin: calc(var(--base) / 2) 0;
+      margin: 0.5rem 0;
   }
 }

--- a/src/app/_components/Message/index.module.scss
+++ b/src/app/_components/Message/index.module.scss
@@ -1,11 +1,11 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .message {
   background-color: var(--highlight-info-bg-color);
   color: var(--highlight-info-text-color);
-  padding: calc(var(--base) / 2) var(--base);
+  padding: 0.5rem 1rem;
   display: flex;
   position: relative;
 
@@ -17,7 +17,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     left: 0;
     top: 0;
     background-color: currentColor;
-    opacity: .5;
+    opacity: 0.5;
   }
 }
 
@@ -37,10 +37,10 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .icon {
-  margin-right: calc(var(--base) / 2);
+  margin-right: 0.5rem;
   padding: 6px;
-  width: calc(var(--base) * 1.75);
-  height: calc(var(--base) * 1.75);
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 100%;
   display: flex;
   align-items: center;

--- a/src/app/_components/NewProject/index.module.scss
+++ b/src/app/_components/NewProject/index.module.scss
@@ -4,7 +4,7 @@
     width: 100%;
     display: flex;
     align-items: flex-end;
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
 
     @include mid-break {
         margin-bottom: 0;
@@ -22,22 +22,22 @@
 
 .headerContent {
     flex-grow: 1;
-    
+
     @include mid-break {
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
     }
 }
 
 .callToAction {
     @include shadow;
     background-color: var(--theme-elevation-50);
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
     position: relative;
     width: calc(100% + var(--gutter-h));
     left: calc(var(--gutter-h) * -0.5);
 
     @include mid-break {
-        padding: calc(var(--base) * 1.5);
+        padding: 1.5rem;
         width: calc(100% + (var(--gutter-h) * 2));
         left: calc(var(--gutter-h) * -1);
     }
@@ -48,7 +48,7 @@
     bottom: 0;
     left: 0;
     width: calc(100% + var(--gutter-h));
-    height: calc(50% + calc(var(--base) * 3));
+    height: calc(50% + 3rem);
     margin-left: calc(var(--gutter-h) / -2);
 
     @include mid-break {
@@ -69,24 +69,24 @@
     position: relative;
     display: flex;
     flex-wrap: wrap;
-    width: calc(100% + (var(--base) * 2));
-    left: calc(var(--base) * -1);
-    padding-bottom: calc(var(--base) * 6);
+    width: calc(100% + (2rem));
+    left: -1rem;
+    padding-bottom: 6rem;
 
     @include mid-break {
         flex-wrap: wrap;
-        width: calc(100% + var(--base));
-        left: calc(var(--base) * -0.5);
-        padding-bottom: calc(var(--base) * 2);
+        width: calc(100% + 1rem);
+        left: -.5rem;
+        padding-bottom: 2rem;
     }
 }
 
 .card {
-    width: calc(33.333% - (var(--base) * 2));
-    margin: calc(var(--base) * 1);
+    width: calc(33.333% - (2rem));
+    margin: 1rem;
 
     @include mid-break {
-        width: calc(100% - var(--base));
-        margin: calc(var(--base) * 0.5);
+        width: calc(100% - 1rem);
+        margin: 0.5rem;
     }
 }

--- a/src/app/_components/RenderParams/index.module.scss
+++ b/src/app/_components/RenderParams/index.module.scss
@@ -1,9 +1,9 @@
 @use '@scss/common.scss' as *;
 
 .renderParams {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include mid-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }

--- a/src/app/_components/SimpleLogs/index.module.scss
+++ b/src/app/_components/SimpleLogs/index.module.scss
@@ -30,13 +30,13 @@
     margin-bottom: 0;
   }
 }
-  
+
 .logTimestamp {
   margin-bottom: 0;
   flex-shrink: 0;
   color: var(--theme-elevation-500);
 }
-  
+
 .lineMessage {
   color: var(--theme-text);
 
@@ -53,7 +53,7 @@
     color: inherit;
   }
   .logTimestamp {
-    opacity: .5;
+    opacity: 0.5;
   }
 }
 

--- a/src/app/community-help/(posts)/discord/[slug]/index.module.scss
+++ b/src/app/community-help/(posts)/discord/[slug]/index.module.scss
@@ -7,17 +7,17 @@
 }
 
 .openPostWrap {
-  margin: 0 calc(var(--base) * -4);
+  margin: 0 -4rem;
 }
 
 .post {
   height: 100%;
-  padding: var(--base) 0;
-  margin: var(--base) calc(var(--base) * 4) calc(var(--base) * 2) calc(var(--base) * 4);
+  padding: 1rem 0;
+  margin: 1rem 4rem 2rem 4rem;
 }
 
 .ctaWrap {
-  margin-top: calc(var(--base) * 5);
+  margin-top: 5rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
@@ -32,14 +32,14 @@
 
 @include mid-break {
   .post {
-    margin: var(--base);
+    margin: 1rem;
   }
 
   .wrap {
-    padding-bottom: calc(var(--base) * 1.5);
+    padding-bottom: 1.5rem;
   }
 
   .openPostWrap {
-    margin: 0 calc(var(--base) * -1);
+    margin: 0 -1rem;
   }
 }

--- a/src/app/community-help/(posts)/github/[slug]/index.module.scss
+++ b/src/app/community-help/(posts)/github/[slug]/index.module.scss
@@ -6,17 +6,17 @@
 }
 
 .openPostWrap {
-  margin: 0 calc(var(--base) * -4);
+  margin: 0 -4rem;
 }
 
 .post {
   height: 100%;
-  padding-top: calc(var(--base)*2);
-  margin: 0 calc(var(--base) * 4);
+  padding-top: 2rem;
+  margin: 0 4rem;
 }
 
 .ctaWrap {
-  margin-top: calc(var(--base) * 5);
+  margin-top: 5rem;
   border-top: 1px solid var(--theme-border-color);
 }
 
@@ -30,14 +30,14 @@
 
 @include mid-break {
   .post {
-    margin: var(--base);
+    margin: 1rem;
   }
 
   .wrap {
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 
   .openPostWrap {
-    margin: 0 calc(var(--base) * -1);
+    margin: 0 -1rem;
   }
 }

--- a/src/app/community-help/ArchiveSearchBar/index.module.scss
+++ b/src/app/community-help/ArchiveSearchBar/index.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   position: relative;
-  height: calc(var(--base) * 3);
+  height: 3rem;
 
   @include mid-break {
     left: 0;
@@ -19,8 +19,8 @@
   font-family: var(--font-body);
   font-size: var(--font-body-size);
   flex-grow: 1;
-  height: calc(var(--base) * 2);
-  margin-right: calc(var(--base) * 0.5);
+  height: 2rem;
+  margin-right: 0.5rem;
   text-transform: none;
 
   &::placeholder {
@@ -35,8 +35,8 @@
 .searchIcon {
   display: flex;
   align-items: center;
-  width: var(--base);
-  height: var(--base);
+  width: 1rem;
+  height: 1rem;
 }
 
 :global([data-theme="light"]) {

--- a/src/app/community-help/index.module.scss
+++ b/src/app/community-help/index.module.scss
@@ -4,7 +4,7 @@
   height: 100%;
   position: relative;
   margin-top: var(--page-padding-top);
-  padding-bottom: calc(var(--base) * 3);
+  padding-bottom: 3rem;
   border-top: 1px solid var(--theme-border-color);
   border-bottom: 1px solid var(--theme-border-color);
 
@@ -18,7 +18,7 @@
 }
 
 .grid {
-  padding-top: calc(var(--base) * 2);
+  padding-top: 2rem;
 }
 
 .postsWrap {
@@ -45,25 +45,25 @@
   justify-content: space-between;
 
   @include mid-break {
-    padding: 0 calc(var(--base) * 2);
+    padding: 0 2rem;
   }
 }
 
 .postContent, .searchBarWrap, .heading {
-  padding: calc(var(--base) * 1.75) calc(var(--base) * 5);
+  padding: 1.75rem 5rem;
   margin: 0;
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+    padding: 1.5rem 2rem;
   }
 }
 
 .pagination {
-  margin-top: calc(var(--base) * 3);
-  padding: 0 calc(var(--base) * 5);
+  margin-top: 3rem;
+  padding: 0 5rem;
 
   @include mid-break {
-    padding: 0 calc(var(--base) * 2);
+    padding: 0 2rem;
   }
 }
 
@@ -73,38 +73,38 @@
   hyphens: auto;
 
   @include small-break {
-    margin-bottom: calc(var(--base)*0.25);
+    margin-bottom: 0.25rem;
   }
 }
 
 .titleMeta {
   display: flex;
   align-items: center;
-  margin-top: calc(var(--base) * .25);
+  margin-top: 0.25rem;
   color: var(--theme-elevation-500);
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
 }
 
 .platform {
   display: inline-flex;
-  margin-right: calc(var(--base) * .25);
+  margin-right: 0.25rem;
 }
 
 .upvotes {
   display: flex;
   justify-content: flex-end;
   color: var(--theme-elevation-500);
-  margin-left: var(--base);
+  margin-left: 1rem;
   flex-shrink: 0;
   line-height: 42px;
 
   & svg {
-    width: calc(var(--base) * .75);
-    margin-right: calc(var(--base) * .35);
+    width: 0.75rem;
+    margin-right: 0.35rem;
   }
 
   & span:not(:last-child) {
-    padding-right: var(--base);
+    padding-right: 1rem;
   }
 
   @include mid-break {
@@ -123,7 +123,7 @@
 
 .ctaWrap {
   position: relative;
-  padding-top: calc(var(--base) * 4);
+  padding-top: 4rem;
 
   & > * {
     position: sticky;

--- a/src/blocks/CallToAction/index.module.scss
+++ b/src/blocks/CallToAction/index.module.scss
@@ -8,7 +8,7 @@
   position: relative;
 
   @include mid-break {
-    row-gap: calc(var(--base) * 3);
+    row-gap: 3rem;
   }
 }
 
@@ -38,7 +38,7 @@
 
 
 .buttonIcon {
-    margin-left: var(--base);
+    margin-left: 1rem;
     flex-shrink: 0;
     top: 4px;
     position: relative;
@@ -47,7 +47,7 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 
   * {
     margin: 0;
@@ -57,7 +57,7 @@
 .scanline {
   top: 50%;
   transform: translateY(-50%);
-  height: calc(100% + var(--base) * 10);
+  height: calc(100% + 10rem);
   margin-right: calc(var(--gutter-h) * -1);
   width: calc(100% + var(--gutter-h));
   z-index: 0;
@@ -76,13 +76,13 @@
 
 .crosshairTopLeft {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   z-index: 5;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
-  top: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  top: -.5rem;
+  left: -.5rem;
   display: none;
 
   @include mid-break {
@@ -92,13 +92,13 @@
 
 .crosshairBottomRight {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   z-index: 5;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
   display: none;
 
   @include mid-break {

--- a/src/blocks/Callout/index.module.scss
+++ b/src/blocks/Callout/index.module.scss
@@ -7,12 +7,12 @@
 .container {
   position: relative;
   align-items: center;
-  padding-top: calc(var(--base) * 5);
-  padding-bottom: calc(var(--base) * 5);
+  padding-top: 5rem;
+  padding-bottom: 5rem;
   background: var(--theme-bg);
 
   @include mid-break {
-    padding-top: calc(var(--base) * 2);
+    padding-top: 2rem;
     padding-bottom: 0;
   }
 }
@@ -27,31 +27,31 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: calc(var(--base) * 3);
+  padding-top: 3rem;
 
 
   @include mid-break {
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
   }
 }
 
 .content {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 
 .media {
   width: calc(100% + var(--gutter-h));
   margin-right: calc(var(--gutter-h));
-  margin-top: calc(var(--base) * -2.5);
-  margin-bottom: calc(var(--base) * -2.5);
+  margin-top: -2.5rem;
+  margin-bottom: -2.5rem;
 
   @include mid-break {
     margin: 0;
     margin-left: 1px;
     margin-right: 0;
     width: calc(100% - 2px);
-    margin-bottom: calc(var(--base) * -1);
+    margin-bottom: -1rem;
   }
 }
 
@@ -62,7 +62,7 @@
 
 .quoteIcon {
   position: absolute;
-  width:  calc(var(--base) * 1.125);
+  width:  1.125rem;
   height: auto;
   color: var(--theme-text);
   left: 0;
@@ -70,11 +70,11 @@
 
 
   @include large-break {
-    width:  calc(var(--base) * 1);
+    width:  1rem;
   }
 
   @include mid-break {
-    left: calc(var(--base) * 2);
+    left: 2rem;
   }
 
   & path {
@@ -86,7 +86,7 @@
 .authorWrapper {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) *1.2);
+  gap: 1.2rem;
 }
 
 .author {
@@ -94,7 +94,7 @@
 }
 
 .logo {
-  max-width: calc(var(--base) * 6);
+  max-width: 6rem;
   height: auto;
 }
 

--- a/src/blocks/CardGrid/index.module.scss
+++ b/src/blocks/CardGrid/index.module.scss
@@ -13,7 +13,7 @@
   padding-bottom: var(--wrapper-padding-top);
 
   @include mid-break {
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 }
 
@@ -26,12 +26,12 @@
 
 .richText {
   @include mid-break {
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 
   @include small-break {
     h2 {
-      font-size: calc(var(--base) * 1.4);
+      font-size: 1.4rem;
     }
   }
 }

--- a/src/blocks/CaseStudiesHighlight/index.module.scss
+++ b/src/blocks/CaseStudiesHighlight/index.module.scss
@@ -21,7 +21,7 @@
 
 .poweredByPayload {
   position: absolute;
-  top: calc(var(--base) * 4);
+  top: 4rem;
   z-index: 1;
   width: 100%;
   pointer-events: none;
@@ -29,7 +29,7 @@
   justify-content: center;
 
   @include mid-break {
-    top: var(--base);
+    top: 1rem;
   }
 }
 
@@ -37,20 +37,20 @@
   @include large-body;
   @include shadow-lg;
   background: var(--theme-bg);
-  padding: calc(var(--base) * 1.5) calc(var(--base) * 2.5);
-  margin-top: var(--base);
+  padding: 1.5rem 2.5rem;
+  margin-top: 1rem;
   display: flex;
   align-items: center;
   border-bottom: 4px solid;
 
   svg {
-    margin-right: calc(var(--base) * .75);
-    width: calc(var(--base) * 1.5);
-    height: calc(var(--base) * 1.5)
+    margin-right: 0.75rem;
+    width: 1.5rem;
+    height: 1.5rem
   }
 
   @include mid-break {
-    padding: var(--base) calc(var(--base) * 2);
+    padding: 1rem 2rem;
   }
 }
 
@@ -68,14 +68,14 @@
   &:nth-child(even) {
     left: 20vh;
   }
-  
+
   @include large-break {
     flex-wrap: wrap;
 
     &:nth-child(odd) {
       right: 15vh;
     }
-  
+
     &:nth-child(even) {
       left: 15vh;
     }
@@ -87,7 +87,7 @@
     &:nth-child(odd) {
       right: 5vh;
     }
-  
+
     &:nth-child(even) {
       left: 5vh;
     }
@@ -108,10 +108,10 @@
 
 .imageWrap {
   width: 33.33%;
-  padding: var(--base);
+  padding: 1rem;
 
   @include large-break {
-    padding: calc(var(--base) * .5);
+    padding: 0.5rem;
   }
 
   @include mid-break {
@@ -125,12 +125,12 @@
   padding-top: 56.25%;
   position: relative;
   height: 100%;
-  opacity: .3;
+  opacity: 0.3;
 
   &:hover {
     @include shadow-lg;
     opacity: 1;
-    transform: translate3d(0, calc(var(--base) * -1), 0);
+    transform: translate3d(0, -1rem, 0);
   }
 
   @include mid-break {

--- a/src/blocks/CaseStudyCards/index.module.scss
+++ b/src/blocks/CaseStudyCards/index.module.scss
@@ -6,10 +6,10 @@
 
 .cards {
   position: relative;
-  padding: calc(var(--base) * 4) 0;
+  padding: 4rem 0;
 
   @include mid-break {
-    padding: calc(var(--base) * 2) 0;
+    padding: 2rem 0;
   }
 }
 
@@ -18,7 +18,7 @@
 }
 
 .scanline {
-  --margin: min(calc(var(--gutter-h) / 2), calc(var(--base) * 4));
+  --margin: min(calc(var(--gutter-h) / 2), 4rem);
   margin-left: var(--margin);
   margin-right: var(--margin);
   width: calc(100% - var(--margin) * 2);
@@ -46,7 +46,7 @@
   }
 
   &:not(:last-child) {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 
   &:hover {
@@ -56,7 +56,7 @@
         transform: scale(1.05) rotate(-1deg);
       }
       &:after {
-        opacity: .5;
+        opacity: 0.5;
       }
     }
   }
@@ -67,17 +67,17 @@
 }
 
 .content {
-  padding: calc(var(--base) * 4) calc(var(--base) * 3);
+  padding: 4rem 3rem;
   width: auto;
   flex-shrink: 0;
   flex: 1;
 
   @include large-break {
-    padding: calc(var(--base) * 3) calc(var(--base) * 1.5);
+    padding: 3rem 1.5rem;
   }
 
   @include small-break {
-    padding: calc(var(--base) * 1.5) var(--base);
+    padding: 1.5rem 1rem;
   }
 
   * {
@@ -100,7 +100,7 @@
     background-color: var(--theme-elevation-700);
     opacity: 0;
     mix-blend-mode: hard-light;
-    transition: opacity .25s ease;
+    transition: opacity 0.25s ease;
   }
 
   img {

--- a/src/blocks/CaseStudyParallax/index.module.scss
+++ b/src/blocks/CaseStudyParallax/index.module.scss
@@ -10,10 +10,10 @@
 
 .card {
   position: relative;
-  padding-top:  calc(var(--base) * 4);
+  padding-top:  4rem;
 
   &.isFirst {
-    margin-top: calc(var(--base) * -12);
+    margin-top: -12rem;
     grid-column: 1/-1;
     grid-row: 1/1;
   }
@@ -36,7 +36,7 @@
   }
 
   &:last-of-type {
-    padding-bottom: calc(var(--base) * 4);
+    padding-bottom: 4rem;
 
     @include mid-break {
       padding-bottom:  0;
@@ -79,17 +79,17 @@
 
 .quoteIcon {
   position: absolute;
-  width:  calc(var(--base) * 10);
+  width:  10rem;
   height: auto;
   color: var(--theme-bg);
-  left: calc(var(--base) * -2.4);
-  top: calc(var(--base) * -5.6);
+  left: -2.4rem;
+  top: -5.6rem;
 
 
   @include large-break {
-    left: calc(var(--base) * -1.8);
-    top: calc(var(--base) * -4.5);
-    width:  calc(var(--base) * 8);
+    left: -1.8rem;
+    top: -4.5rem;
+    width:  8rem;
   }
 
   @include mid-break {
@@ -107,12 +107,12 @@
   @include h3;
   font-weight: 500;
   line-height: 1.2;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   position: relative;
   letter-spacing: -0.04em;
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 1);
+    margin-bottom: 1rem;
   }
 }
 
@@ -134,17 +134,17 @@
   position: relative;
   scroll-snap-align: center;
   overflow: visible;
-  row-gap: calc(var(--base) * 12);
+  row-gap: 12rem;
 
-  padding-top:  calc(var(--base) * 16);
-  padding-bottom:  calc(var(--base) * 10);
+  padding-top: 16rem;
+  padding-bottom:  10rem;
 
   margin-bottom: -80vh;
 
   @include mid-break {
     margin-bottom: 0;
-    row-gap: calc(var(--base) * 4);
-    padding-top:  calc(var(--base) * 1);
+    row-gap: 4rem;
+    padding-top:  1rem;
     padding-bottom:  0;
   }
 }
@@ -160,7 +160,7 @@
 
 .mobileQuoteItem {
   display: none;
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
 
   @include mid-break {
     display: grid;
@@ -178,11 +178,11 @@
 .authorWrapper {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 2);
-  margin-bottom: calc(var(--base) * 2);
+  gap: 2rem;
+  margin-bottom: 2rem;
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 1);
+    margin-bottom: 1rem;
   }
 }
 
@@ -289,7 +289,7 @@
     }
 
     & .navButtonLabel {
-      padding: calc(var(--base) * 0.5) 0;
+      padding: 0.5rem 0;
       opacity: 0.6;
     }
 
@@ -303,6 +303,6 @@
 }
 
 .logo {
-  max-width: calc(var(--base) * 6);
+  max-width: 6rem;
   height: auto;
 }

--- a/src/blocks/CodeBlock/index.module.scss
+++ b/src/blocks/CodeBlock/index.module.scss
@@ -1,3 +1,3 @@
 .codeBlock {
-  margin: var(--base) 0;
+  margin: 1rem 0;
 }

--- a/src/blocks/CodeFeature/index.module.scss
+++ b/src/blocks/CodeFeature/index.module.scss
@@ -13,13 +13,13 @@
 .container {
   position: relative;
   align-items: center;
-  row-gap: calc(var(--base) * 3);
+  row-gap: 3rem;
 
   @include mid-break {
-    row-gap: calc(var(--base) * 0);
+    row-gap: 0;
 
     &.hasLinks {
-      row-gap: calc(var(--base) * 2);
+      row-gap: 2rem;
     }
   }
 }
@@ -30,11 +30,11 @@
 }
 
 .labelWrap {
-  padding: var(--base) var(--base) 0;
+  padding: 1rem 1rem 0;
 }
 
 .label {
-  padding-bottom: var(--base);
+  padding-bottom: 1rem;
   border-bottom: 1px solid var(--color-base-700);
   color: var(--color-base-100);
   margin: 0;
@@ -45,7 +45,7 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }
 
 .links {
@@ -85,8 +85,8 @@
 .tabs {
   position: relative;
   display: flex;
-  gap: calc(var(--base) * 2);
-  padding: 0 calc(var(--base) * 2);
+  gap: 2rem;
+  padding: 0 2rem;
   background: var(--color-base-900);
   overflow-x: auto;
   scroll-behavior: smooth;
@@ -97,7 +97,7 @@
   }
 
   @include mid-break {
-    padding: 0 calc(var(--base) * 1);
+    padding: 0 1rem;
   }
 }
 
@@ -118,7 +118,7 @@
 .tab {
   @include btnReset;
   cursor: pointer;
-  padding: calc(var(--base) * 1) 0;
+  padding: 1rem 0;
   @include body;
   color: var(--color-base-300);
   white-space: nowrap;
@@ -139,30 +139,30 @@
 
 .crosshairTopRight, .crosshairBottomRight, .crosshairTopLeft, .crosshairBottomLeft  {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
 }
 
 .crosshairTopLeft {
-  top: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  top: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairBottomLeft {
-  bottom: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairTopRight {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomRight {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .scanlineDesktopRight,  .scanlineDesktopLeft {

--- a/src/blocks/CodeFeature/index.tsx
+++ b/src/blocks/CodeFeature/index.tsx
@@ -128,7 +128,7 @@ export const CodeFeatureComponent: React.FC<Props> = ({
               ]
                 .filter(Boolean)
                 .join(' ')}
-              style={{ height: `calc(${backgroundHeight}px + var(--base) * 10)` }}
+              style={{ height: `calc(${backgroundHeight}px + 10rem)` }}
             >
               <BackgroundScanline
                 className={[classes.scanlineDesktopLeft].filter(Boolean).join(' ')}
@@ -286,7 +286,7 @@ export const CodeFeatureComponent: React.FC<Props> = ({
               className={[classes.scanlineWrapper, 'start-9 cols-8 start-m-1 cols-m-8']
                 .filter(Boolean)
                 .join(' ')}
-              style={{ height: `calc(${backgroundHeight}px + var(--base) * 10)` }}
+              style={{ height: `calc(${backgroundHeight}px + 10rem)` }}
             >
               <BackgroundScanline
                 className={[classes.scanlineDesktopRight].filter(Boolean).join(' ')}

--- a/src/blocks/Content/index.module.scss
+++ b/src/blocks/Content/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .leadingHeader {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   max-width: 1400px;
 
   @include extra-large-break {

--- a/src/blocks/ContentGrid/index.module.scss
+++ b/src/blocks/ContentGrid/index.module.scss
@@ -8,18 +8,18 @@
 
 .topContent {
   align-items: start;
-  row-gap: calc(var(--base) * 2);
+  row-gap: 2rem;
 
   &.gridBelow {
-    margin-bottom: calc(var(--base) * 6);
+    margin-bottom: 6rem;
 
     @include mid-break {
-      margin-bottom: calc(var(--base) * 3);
+      margin-bottom: 3rem;
     }
   }
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 3);
+    margin-bottom: 3rem;
   }
 }
 
@@ -30,7 +30,7 @@
 }
 
 .cellGrid {
-  row-gap: calc(var(--base) * 2.5);
+  row-gap: 2.5rem;
 }
 
 .cell {

--- a/src/blocks/ExampleTabs/Tabs/index.module.scss
+++ b/src/blocks/ExampleTabs/Tabs/index.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: calc(var(--base) * 2);
+  gap: 2rem;
 }
 
 .content {
@@ -31,7 +31,7 @@
   }
 
   button {
-    padding: var(--base) var(--base);
+    padding: 1rem 1rem;
     border: none;
     background-color: transparent;
     font-size: var(--font-body);

--- a/src/blocks/ExampleTabs/index.module.scss
+++ b/src/blocks/ExampleTabs/index.module.scss
@@ -1,7 +1,7 @@
 .exampleTabsBlock {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 2);
+  gap: 2rem;
 }
 
 .content {

--- a/src/blocks/FormBlock/index.module.scss
+++ b/src/blocks/FormBlock/index.module.scss
@@ -147,7 +147,7 @@
   position: relative;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2)
+    margin-bottom: 2rem
   }
 }
 

--- a/src/blocks/HoverCards/index.module.scss
+++ b/src/blocks/HoverCards/index.module.scss
@@ -1,6 +1,6 @@
 @use "@scss/common" as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .wrapper {
     position: relative;
@@ -8,7 +8,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .introWrapper {
-  padding-bottom: calc(var(--base) * 8);
+  padding-bottom: 8rem;
   align-items: center;
   align-content: center;
   padding-bottom: var(--wrapper-padding-top);
@@ -18,7 +18,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   }
 
   @include mid-break {
-    padding-bottom: calc(var(--base) * 2);
+    padding-bottom: 2rem;
   }
 }
 
@@ -31,24 +31,24 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   height: 100%;
   text-decoration: none;
   position: relative;
-  padding: calc(var(--base) * 2);
+  padding: 2rem;
   display: flex;
   flex-direction: column;
-  row-gap: calc(var(--base) * 1.5);
+  row-gap: 1.5rem;
 
   &:active {
     text-decoration: none;
   }
 
   @include large-break {
-    padding-top: calc(var(--base) * 3);
-    padding-bottom: calc(var(--base) * 3);
+    padding-top: 3rem;
+    padding-bottom: 3rem;
   }
 
   @include mid-break {
     border-bottom: 1px solid var(--grid-line-dark);
-    padding-top: calc(var(--base) * 2);
-    padding-bottom: calc(var(--base) * 2);
+    padding-top: 2rem;
+    padding-bottom: 2rem;
   }
 
   @include small-break {
@@ -97,8 +97,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .arrow {
   position: absolute;
-  top: calc(var(--base) * 2);
-  right: calc(var(--base) * 2);
+  top: 2rem;
+  right: 2rem;
   opacity: 0;
   transform: translateY(10px);
   transition: all 350ms $curve;
@@ -123,14 +123,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .leader {
   @include h6;
   margin-top: 0;
-  margin-bottom: calc(var(--base) * 4);
+  margin-bottom: 4rem;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 7);
+    margin-bottom: 7rem;
   }
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 }
 
@@ -138,7 +138,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   @include h4;
   position: relative;
   transition: all 350ms $curve;
-  margin-bottom: calc(var(--base) * 1);
+  margin-bottom: 1rem;
   text-decoration: none;
 }
 

--- a/src/blocks/HoverHighlights/HoverHighlight/index.module.scss
+++ b/src/blocks/HoverHighlights/HoverHighlight/index.module.scss
@@ -11,7 +11,7 @@ $transTime: 300ms;
 }
 
 .highlight {
-    padding: calc(var(--base) * 3) 0;
+    padding: 3rem 0;
     opacity: 0.5;
     transition: opacity 0.3s ease-in-out;
     width: 100%;
@@ -21,7 +21,7 @@ $transTime: 300ms;
     }
 
     @include mid-break {
-        padding: calc(var(--base) * 2) 0;
+        padding: 2rem 0;
         opacity: 1;
     }
 }
@@ -32,7 +32,7 @@ $transTime: 300ms;
 
 .hr {
     margin: 0;
-    background-size: calc(300% + var(--base)) 1px;
+    background-size: calc(300% + 1rem) 1px;
 }
 
 .description {
@@ -40,7 +40,7 @@ $transTime: 300ms;
 }
 
 .richTextGrid {
-    // margin-bottom: calc(var(--base) * 4);
+    // margin-bottom: 4rem;
 }
 
 .rowNumber {
@@ -58,11 +58,11 @@ $transTime: 300ms;
 
 .content  {
     position: relative;
-    padding: calc(var(--base) * 4) 0;
+    padding: 4rem 0;
     width: calc(100% + var(--gutter-h));
 
     @include mid-break {
-        padding: calc(var(--base) * 2) 0;
+        padding: 2rem 0;
     }
 }
 

--- a/src/blocks/HoverHighlights/index.module.scss
+++ b/src/blocks/HoverHighlights/index.module.scss
@@ -9,7 +9,7 @@
 }
 
 .highlight {
-    padding: calc(var(--base) * 4) 0;
+    padding: 4rem 0;
     opacity: 0.5;
     transition: opacity 0.3s ease-in-out;
     width: 100%;
@@ -19,7 +19,7 @@
     }
 
     @include mid-break {
-        padding: calc(var(--base) * 2) 0;
+        padding: 2rem 0;
     }
 }
 
@@ -36,7 +36,7 @@
 }
 
 .richTextGrid {
-    // margin-bottom: calc(var(--base) * 4);
+    // margin-bottom: 4rem;
 }
 
 .rowNumber {
@@ -45,11 +45,11 @@
 
 .content  {
     position: relative;
-    padding: calc(var(--base) * 4) 0;
+    padding: 4rem 0;
     width: calc(100% + var(--gutter-h));
 
     @include mid-break {
-        padding: calc(var(--base) * 2) 0;
+        padding: 2rem 0;
     }
 }
 

--- a/src/blocks/LinkGrid/index.module.scss
+++ b/src/blocks/LinkGrid/index.module.scss
@@ -24,10 +24,10 @@
   display: flex;
   align-items: flex-start;
   margin: 0;
-  padding: calc(var(--base) * 3) calc(var(--base) * 1.5);
+  padding: 3rem 1.5rem;
   background-color: var(--theme-elevation-0);
   border-bottom: 1px solid var(--grid-line-dark);
-  transition: padding-left 0.3s cubic-bezier(.165, .84, .44, 1);
+  transition: padding-left 0.3s cubic-bezier(.165, 0.84, 0.44, 1);
 
   @include data-theme-selector('light') {
     border-color: var(--grid-line-light);
@@ -45,11 +45,11 @@
     width: 0px;
     height: 2px;
     background-color: var(--theme-elevation-1000);
-    transition: width 0.6s cubic-bezier(.165, .84, .44, 1);
+    transition: width 0.6s cubic-bezier(.165, 0.84, 0.44, 1);
   }
 
   &:hover {
-    padding-left: calc(var(--base) * 2);
+    padding-left: 2rem;
     &::before {
       width: 100%;
     }
@@ -62,8 +62,8 @@
 }
 
 .arrow {
-  transform: translate(calc(var(--base) / -2), calc(var(--base) / 2));
-  transition: transform .3s cubic-bezier(.165, .84, .44, 1);
+  transform: translate(-.5rem, 0.5rem);
+  transition: transform 0.3s cubic-bezier(.165, 0.84, 0.44, 1);
 
   @include mid-break {
     transform: scale(.75);

--- a/src/blocks/LogoGrid/index.module.scss
+++ b/src/blocks/LogoGrid/index.module.scss
@@ -10,25 +10,25 @@
 
 .richTextWrapper {
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 }
 
 .richText {
   max-width: 75%;
-  margin-bottom: calc(var(--base) * 3);
+  margin-bottom: 3rem;
 
   @include mid-break {
     max-width: 100%;
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 }
 
@@ -106,19 +106,19 @@
 
   .contentWrapper {
     position: absolute;
-    top: calc(var(--base) * 1.5);
-    bottom: calc(var(--base) * 1.5);
-    left: calc(var(--base) * 1.5);
-    right: calc(var(--base) * 1.5);
+    top: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+    right: 1.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
 
     @include small-break {
-      top: calc(var(--base) * 1);
-      bottom: calc(var(--base) * 1);
-      left: calc(var(--base) * 1);
-      right: calc(var(--base) * 1);
+      top: 1rem;
+      bottom: 1rem;
+      left: 1rem;
+      right: 1rem;
     }
 
     > div {
@@ -129,7 +129,7 @@
       opacity: 0;
       filter: blur(0px);
     }
-  }  
+  }
 }
 
 .logoPresent {
@@ -154,7 +154,7 @@
 
 .crosshair {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   z-index: 5;
   color: var(--theme-elevation-1000);
@@ -162,13 +162,13 @@
 }
 
 .crosshairLeft {
-  left: calc(25% + var(--base) * -0.45);
-  bottom: calc(50% + var(--base) * -0.55);
+  left: calc(25% + -.45rem);
+  bottom: calc(50% + -.55rem);
 }
 
 .crosshairRight {
-  left: calc(75% + var(--base) * -0.45);
-  bottom: calc(50% + var(--base) * -0.55);
+  left: calc(75% + -.45rem);
+  bottom: calc(50% + -.55rem);
 }
 
 :global([data-theme="dark"]) {

--- a/src/blocks/MediaBlock/index.module.scss
+++ b/src/blocks/MediaBlock/index.module.scss
@@ -12,5 +12,5 @@
 .caption {
   display: flex;
   justify-content: center;
-  padding-top: calc(var(--base) * 1.25);
+  padding-top: 1.25rem;
 }

--- a/src/blocks/MediaContent/index.module.scss
+++ b/src/blocks/MediaContent/index.module.scss
@@ -29,13 +29,13 @@
   justify-content: center;
 
   @include mid-break {
-    margin-top: var(--base);
+    margin-top: 1rem;
   }
 }
 
 .button {
   display: block;
-  margin-top: calc(var(--base) * 2);
+  margin-top: 2rem;
   width: calc(4/6 * 100%);
 
   a {
@@ -44,6 +44,6 @@
 
   @include mid-break {
     width: 100%;
-    margin-top: var(--base);
+    margin-top: 1rem;
   }
 }

--- a/src/blocks/MediaContentAccordion/Desktop/index.module.scss
+++ b/src/blocks/MediaContentAccordion/Desktop/index.module.scss
@@ -32,7 +32,7 @@
 
 .crosshairTopOne, .crosshairTopTwo, .crosshairBottomOne, .crosshairBottomTwo {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
@@ -40,55 +40,55 @@
 }
 
 .crosshairTopOne {
-  top: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  top: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairTopTwo {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomOne {
-  bottom: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairBottomTwo {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairTopRight, .crosshairBottomRight {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
 }
 
 .crosshairTopRight {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomRight {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .introWrapper {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-bottom: calc(var(--base) * 3.5);
+  padding-bottom: 3.5rem;
 }
 
 .leader {
   @include h6;
   text-transform: uppercase;
   margin-top: 0;
-  margin-bottom: calc(var(--base) * 1);
+  margin-bottom: 1rem;
   color: #4D90B2;
 }
 
@@ -172,7 +172,7 @@
   cursor: pointer;
   width: 100%;
   text-align: unset;
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -248,7 +248,7 @@
   font-size: 16px;
   line-height: 150%;
   color: var(--text-dark);
-  padding: 0 calc(var(--base) * 1.5) calc(var(--base) * 1.5) calc(var(--base) * 1.5);
+  padding: 0 1.5rem 1.5rem 1.5rem;
 
   @include data-theme-selector('light') {
     color: var(--text-light);
@@ -260,21 +260,21 @@
 }
 
 .mediaDescription {
-  padding-bottom: calc(var(--base) * 1);
+  padding-bottom: 1rem;
 }
 
 .link {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
   color: var(--color-base-0);
   font-weight: 500;
   text-decoration: none;
 
   .arrowIcon {
-    width: calc(var(--base) * 0.75);
-    height: calc(var(--base) * 0.75);
+    width: 0.75rem;
+    height: 0.75rem;
     transition: transform 0.3s ease;
   }
 

--- a/src/blocks/MediaContentAccordion/Desktop/index.tsx
+++ b/src/blocks/MediaContentAccordion/Desktop/index.tsx
@@ -110,7 +110,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <Image
                           alt=""
@@ -141,7 +141,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <BackgroundScanline
                           className={[classes.scanlineDesktop].filter(Boolean).join(' ')}
@@ -168,7 +168,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <div className={classes.transparentBg} />
                       </div>
@@ -339,7 +339,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <Image
                           alt=""
@@ -370,7 +370,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <BackgroundScanline
                           className={[classes.scanlineDesktop].filter(Boolean).join(' ')}
@@ -397,7 +397,7 @@ export const DesktopMediaContentAccordion: React.FC<MediaContentAccordionProps> 
                         ]
                           .filter(Boolean)
                           .join(' ')}
-                        style={{ height: `calc(${containerHeight}px + var(--base) * 8)` }}
+                        style={{ height: `calc(${containerHeight}px + 8rem)` }}
                       >
                         <div className={classes.transparentBg} />
                       </div>

--- a/src/blocks/MediaContentAccordion/Mobile/index.module.scss
+++ b/src/blocks/MediaContentAccordion/Mobile/index.module.scss
@@ -10,14 +10,14 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding-bottom: calc(var(--base) * 3);
+  padding-bottom: 3rem;
 }
 
 .leader {
   @include h6;
   text-transform: uppercase;
   margin-top: 0;
-  margin-bottom: calc(var(--base) * 1);
+  margin-bottom: 1rem;
   color: #4D90B2;
 }
 
@@ -29,7 +29,7 @@
 
 .mediaBackgroundWrapper {
   position: relative;
-  margin-bottom: calc(var(--base) * 3);
+  margin-bottom: 3rem;
 }
 
 .gradientBg {
@@ -54,7 +54,7 @@
 
 .crosshairTopOne, .crosshairTopTwo, .crosshairBottomOne, .crosshairBottomTwo {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
@@ -62,41 +62,41 @@
 }
 
 .crosshairTopOne {
-  top: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  top: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairTopTwo {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomOne {
-  bottom: calc(var(--base) * -0.5);
-  left: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  left: -.5rem;
 }
 
 .crosshairBottomTwo {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairTopRight, .crosshairBottomRight {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
 }
 
 .crosshairTopRight {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomRight {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .collapsibleWrapper {
@@ -173,7 +173,7 @@
   cursor: pointer;
   width: 100%;
   text-align: unset;
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -185,7 +185,7 @@
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+    padding: 1.5rem 1rem;
   }
 
   @include data-theme-selector('light') {
@@ -253,7 +253,7 @@
   font-size: 16px;
   line-height: 150%;
   color: var(--text-dark);
-  padding: 0 calc(var(--base) * 1.5) calc(var(--base) * 1.5) calc(var(--base) * 1.5);
+  padding: 0 1.5rem 1.5rem 1.5rem;
 
   @include data-theme-selector('light') {
     color: var(--text-light);
@@ -265,21 +265,21 @@
 }
 
 .mediaDescription {
-  padding-bottom: calc(var(--base) * 1);
+  padding-bottom: 1rem;
 }
 
 .link {
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
   color: var(--color-base-0);
   font-weight: 500;
   text-decoration: none;
 
   .arrowIcon {
-    width: calc(var(--base) * 0.75);
-    height: calc(var(--base) * 0.75);
+    width: 0.75rem;
+    height: 0.75rem;
     transition: transform 0.3s ease;
   }
 

--- a/src/blocks/MediaContentAccordion/Mobile/index.tsx
+++ b/src/blocks/MediaContentAccordion/Mobile/index.tsx
@@ -85,7 +85,7 @@ export const MobileMediaContentAccordion: React.FC<MediaContentAccordionProps> =
         </div>
         <div
           className={classes.mediaBackgroundWrapper}
-          style={{ height: `calc(${containerHeight}px + var(--base) * 6)` }}
+          style={{ height: `calc(${containerHeight}px + 6rem)` }}
         >
           {hasAccordion &&
             accordion.map((item, index) => (

--- a/src/blocks/Pricing/index.module.scss
+++ b/src/blocks/Pricing/index.module.scss
@@ -23,7 +23,7 @@
   border-bottom: 1px solid var(--grid-line-dark);
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
 
     &:last-of-type {
       margin-bottom: 0;
@@ -41,18 +41,18 @@
 
 .crosshairTopLeft {
   position: absolute;
-  top: calc(var(--base) * -.5);
-  left: calc(var(--base) * -.5);
-  width: calc(var(--base) * 1);
+  top: -.5rem;
+  left: -.5rem;
+  width: 1rem;
   height: auto;
   opacity: 0.15;
 }
 
 .crosshairTopRight {
   position: absolute;
-  top: calc(var(--base) * -.5);
-  right: calc(var(--base) * -.5);
-  width: calc(var(--base) * 1);
+  top: -.5rem;
+  right: -.5rem;
+  width: 1rem;
   height: auto;
   opacity: 0.15;
 
@@ -62,23 +62,23 @@
 }
 
 .disclaimer {
-    padding-bottom: var(--base);
+    padding-bottom: 1rem;
 }
 
 .createPayloadApp {
   display: flex;
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
   width: 100%;
   @include code;
 
   @include mid-break {
-    padding: calc(var(--base) * 1);
+    padding: 1rem;
   }
 }
 
 .ctaWrapper {
   display: flex;
-  height: calc(var(--base) * 4.2);
+  height: 4.2rem;
   border-bottom: 1px solid var(--grid-line-dark);
 
   @include data-theme-selector('dark') {
@@ -103,17 +103,17 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
 
   @include mid-break {
     padding: 0;
-    padding-left: calc(var(--base) * 1);
-    padding-right: calc(var(--base) * 1);
-    padding-bottom: calc(var(--base) * 1.5);
+    padding-left: 1rem;
+    padding-right: 1rem;
+    padding-bottom: 1.5rem;
   }
 
   .feature {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
     display: flex;
     align-items: center;
 
@@ -122,7 +122,7 @@
     }
 
     @include mid-break {
-      margin-bottom: calc(var(--base) * 0.4);
+      margin-bottom: 0.4rem;
 
       &:last-of-type {
         margin-bottom: 0;
@@ -136,9 +136,9 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: calc(var(--base) * 1.5);
-    height: calc(var(--base) * 1.5);
-    margin-right: calc(var(--base) * 0.8);
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 0.8rem;
     justify-items: center;
   }
 
@@ -172,7 +172,7 @@
 .toggler {
   display: none;
   width: 100%;
-  padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+  padding: 1.5rem 1rem;
   align-items: center;
   justify-content: space-between;
   border: none;
@@ -185,11 +185,11 @@
     margin: 0;
     display: flex;
     background-color: transparent;
-    padding: calc(var(--base) * 1);
+    padding: 1rem;
   }
 
   svg {
-    width: calc(var(--base) * 2);
+    width: 2rem;
     height: 100%;
   }
 }

--- a/src/blocks/RelatedPosts/index.module.scss
+++ b/src/blocks/RelatedPosts/index.module.scss
@@ -2,9 +2,9 @@
 
 .title {
   margin: 0;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .grid {
-  row-gap: calc(var(--base) * 2);
+  row-gap: 2rem;
 }

--- a/src/blocks/Slider/QuoteCard/index.module.scss
+++ b/src/blocks/Slider/QuoteCard/index.module.scss
@@ -1,11 +1,11 @@
 @use '@scss/common' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .quoteCard {
   @include large-body;
   box-sizing: border-box;
-  padding: calc(var(--base) * 5);
+  padding: 5rem;
   display: flex;
   position: relative;
   flex-direction: column;
@@ -79,20 +79,20 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
   @include extra-large-break {
     @include body;
-    padding: calc(var(--base) * 4);
+    padding: 4rem;
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5);
+    padding: 1.5rem;
   }
 }
 
 .icon {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 
   @include mid-break {
     max-width: 25px;
-    margin-bottom: calc(var(--base) / 2);
+    margin-bottom: 0.5rem;
   }
 }
 
@@ -105,7 +105,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   @include h6;
   margin-top: 0;
   text-transform: uppercase;
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }
 
 .closingQuote {
@@ -116,15 +116,15 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   @include h3;
   margin-top: 0;
   position: relative;
-  margin-bottom: calc(var(--base) * 4.5);
+  margin-bottom: 4.5rem;
 
   &::before {
     content: '“';
     position: absolute;
-    left: calc(var(--base) * -1.2);
+    left: -1.2rem;
 
     @include mid-break {
-      left: calc(var(--base) * -0.8);
+      left: -.8rem;
     }
   }
 }
@@ -132,7 +132,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .author {
   @include h5;
   margin-top: 0;
-  margin-bottom: calc(var(--base) * 0.8);
+  margin-bottom: 0.8rem;
 }
 
 .role {

--- a/src/blocks/Slider/index.module.scss
+++ b/src/blocks/Slider/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .leadingHeader {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   max-width: 1200px;
 
   @include extra-large-break {
@@ -11,13 +11,13 @@
 
 .slider {
   position: relative;
-  --pixel-extension-top: calc(var(--base) * 2.5);
-  --pixel-extension-bottom: calc(var(--base) * 5);
+  --pixel-extension-top: 2.5rem;
+  --pixel-extension-bottom: 5rem;
   --pixel-extension-total: calc(var(--pixel-extension-top) + var(--pixel-extension-bottom));
 
   @include mid-break {
-    --pixel-extension-top: calc(var(--base)* 2);
-    --pixel-extension-bottom: calc(var(--base) * 2.25);
+    --pixel-extension-top: 2rem;
+    --pixel-extension-bottom: 2.25rem;
   }
 }
 
@@ -27,21 +27,21 @@
 }
 
 .sliderNav {
-  margin-left: calc(var(--base) * 4.5);
-  margin-top: calc(var(--base) * 2);
+  margin-left: 4.5rem;
+  margin-top: 2rem;
 
   @include mid-break {
-    margin-left: calc(var(--base) * 1);
+    margin-left: 1rem;
   }
 }
 
 .navButton {
   all: unset;
   cursor: pointer;
-  width: calc(var(--base) * 0.6);
+  width: 6rem;
 
   @include mid-break {
-    width: calc(var(--base) * 1);
+    width: 1rem;
   }
 
   svg {
@@ -56,7 +56,7 @@
 }
 
 .prevButton {
-  margin-right: calc(var(--base) * 1.5);
+  margin-right: 1.5rem;
 }
 
 .sliderTrack {

--- a/src/blocks/Statement/index.module.scss
+++ b/src/blocks/Statement/index.module.scss
@@ -38,10 +38,10 @@
 }
 
 .content {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 
   p {

--- a/src/blocks/Steps/Step/index.module.scss
+++ b/src/blocks/Steps/Step/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .step {
-  --step-indicator-pos: calc(var(--base) * 2);
+  --step-indicator-pos: 2rem;
   position: relative;
   padding-bottom: var(--block-spacing);
 
@@ -9,9 +9,9 @@
     content: ' ';
     display: block;
     position: absolute;
-    top: calc(var(--base) * 2);
+    top: 2rem;
     left: calc(var(--gutter-h) - var(--step-indicator-pos) - 5px);
-    bottom: var(--base);
+    bottom: 1rem;
     transition: transform 1500ms ease-out;
     transform-origin: center top;
     transform: scaleY(0);
@@ -20,11 +20,11 @@
   }
 
   @include large-break {
-    --step-indicator-pos: var(--base);
+    --step-indicator-pos: 1rem;
   }
 
   @include mid-break {
-    --step-indicator-pos: calc(var(--base) / 2);
+    --step-indicator-pos: 0.5rem;
   }
 
   &:last-child {
@@ -35,7 +35,7 @@
         background: var(--color-success-500);
       }
     }
-    
+
     &:before {
       content: none;
     }
@@ -57,16 +57,16 @@
     top: 50%;
     transform: translateY(-50%);
     right: calc(100% + var(--step-indicator-pos));
-    width: calc(var(--base) / 2);
-    height: calc(var(--base) / 2);
+    width: 0.5rem;
+    height: 0.5rem;
     background: currentColor;
     border-radius: 100%;
   }
-  
+
   @include mid-break {
     &:before {
-      width: calc(var(--base) / 4);
-      height: calc(var(--base) / 4);
+      width: 0.25rem;
+      height: 0.25rem;
     }
   }
 }

--- a/src/blocks/StickyHighlights/Highlight/index.module.scss
+++ b/src/blocks/StickyHighlights/Highlight/index.module.scss
@@ -18,7 +18,7 @@
     .animate-enter {
       opacity: 0;
       visibility: hidden;
-      transform: translate3d(0, calc(var(--base) * 4), 0);
+      transform: translate3d(0, 4rem, 0);
     }
 
     .animate-enter-active,
@@ -38,7 +38,7 @@
     .animate-exit-active {
       opacity: 0;
       visibility: hidden;
-      transform: translate3d(0, calc(var(--base) * -4), 0);
+      transform: translate3d(0, -4rem, 0);
       transition: all 750ms;
     }
   }
@@ -49,7 +49,7 @@
     .animate-enter {
       opacity: 0;
       visibility: hidden;
-      transform: translate3d(0, calc(var(--base) * -4), 0);
+      transform: translate3d(0, -4rem, 0);
     }
 
     .animate-enter-active,
@@ -69,7 +69,7 @@
     .animate-exit-active {
       opacity: 0;
       visibility: hidden;
-      transform: translate3d(0, calc(var(--base) * 4), 0);
+      transform: translate3d(0, 4rem, 0);
       transition: all 750ms;
     }
   }
@@ -100,7 +100,7 @@
 
   @include large-break-ht {
     top: calc(var(--wrapper-padding-top) / -2);
-    height: calc(100% + var(--base) * 4);
+    height: calc(100% + 4rem);
   }
 
   @include mid-break {
@@ -110,20 +110,20 @@
 
 .crosshairTopRight, .crosshairBottomRight {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   color: var(--theme-elevation-1000);
   opacity: 0.5;
 }
 
 .crosshairTopRight {
-  top: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  top: -.5rem;
+  right: -.5rem;
 }
 
 .crosshairBottomRight {
-  bottom: calc(var(--base) * -0.5);
-  right: calc(var(--base) * -0.5);
+  bottom: -.5rem;
+  right: -.5rem;
 }
 
 .scanlineDesktop {
@@ -143,7 +143,7 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 }
 
 .codeMediaPosition {
@@ -170,7 +170,7 @@
     opacity: 1 !important;
     visibility: visible !important;
     padding: 0 !important;
-    margin: calc(var(--base) * 2) 0 0;
+    margin: 2rem 0 0;
   }
 }
 
@@ -207,33 +207,33 @@
 }
 
 .innerCode {
-  height: calc(var(--base) * 32);
+  height: 32rem;
 
   @include large-break {
-    height: calc(var(--base) * 40);
+    height: 40rem;
   }
 
   @include mid-break {
-    height: calc(var(--base) * 25);
+    height: 25rem;
   }
 
   @include small-break {
-    height: calc(var(--base) * 22);
+    height: 22rem;
   }
 
   @include large-break-ht {
-    height: calc(var(--base) * 28);
+    height: 28rem;
 
     @include large-break {
-      height: calc(var(--base) * 32);
+      height: 32rem;
     }
 
     @include mid-break {
-      height: calc(var(--base) * 25);
+      height: 25rem;
     }
 
     @include small-break {
-      height: calc(var(--base) * 22);
+      height: 22rem;
     }
   }
 }

--- a/src/components/Announcements/index.module.scss
+++ b/src/components/Announcements/index.module.scss
@@ -3,7 +3,7 @@
 .announcementWrap {
   --announcement-bg-color: var(--theme-success-100);
   --announcement-text-color: var(--theme-success-600);
-  --spacer: calc(var(--base) * 2);
+  --spacer: 2rem;
 
   position: fixed;
   bottom: 0;
@@ -18,18 +18,17 @@
 
 .onDocsPage {
   @include mid-break {
-    margin-bottom: calc(var(--base) * 3);
+    margin-bottom: 3rem;
   }
 }
 
 .announcement {
   position: relative;
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   pointer-events: all;
   margin: var(--spacer);
-  padding:
-    var(--base) calc((var(--gutter-h) / 2) - var(--spacer));
+  padding: 1rem calc((var(--gutter-h) / 2) - var(--spacer));
   transition: color 300ms ease;
   border-bottom: 1px solid var(--announcement-text-color);
   color: var(--announcement-text-color);
@@ -43,7 +42,7 @@
     width: 100%;
     height: 100%;
     z-index: -1;
-    opacity: .99;
+    opacity:0.99;
     transition: opacity 500ms ease-out;
     background-color: var(--announcement-bg-color);
   }
@@ -66,9 +65,9 @@
   }
 
   .arrow {
-    margin-left: calc(var(--base) / 2);
-    width: calc(var(--base) * 0.55);
-    height: calc(var(--base) * 0.55);
+    margin-left: 0.5rem;
+    width: 0.55rem;
+    height: 0.55rem;
   }
 
   .close {
@@ -79,8 +78,8 @@
     align-items: center;
 
     svg {
-      width: calc(var(--base) * 0.9);
-      height: calc(var(--base) * 0.9);
+      width:0.9rem;
+      height:0.9rem;
       border-radius: 100%;
       background-color: var(--announcement-text-color);
       color: var(--announcement-bg-color);

--- a/src/components/AuthorTag/index.module.scss
+++ b/src/components/AuthorTag/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .authorTag {
-  --byline-spacer: calc(var(--base) * .75);
+  --byline-spacer: 0.75rem;
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -34,7 +34,7 @@
     height: 40px;
     border-radius: 100%;
     overflow: hidden;
-    margin-right: calc(var(--base) * 0.5);
+    margin-right: 0.5rem;
     flex-shrink: 0;
   }
 }
@@ -60,7 +60,7 @@
 
 .twitterIcon {
   display: flex;
-  margin: 0 0 0 calc(var(--base) * 0.5);
+  margin: 0 0 0 0.5rem;
   width: 18px;
 
   & rect {
@@ -70,7 +70,7 @@
 
 .commentMeta {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   @include label;
 }
 
@@ -83,15 +83,15 @@
 
   &::before {
     content: "\2014";
-    margin: 0 calc(var(--base) * 0.5);
+    margin: 0 0.5rem;
   }
 }
 
 .commentMetaStats {
   display: flex;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
   align-items: flex-end;
-  margin-top: calc(var(--base) * 0.5);
+  margin-top: 0.5rem;
 
   >span {
     font-family: var(--font-mono);
@@ -117,12 +117,12 @@
 
 .comments {
   height: 100%;
-  margin-left: calc(var(--base) * 1.25);
+  margin-left: 1.25rem;
   color: var(--color-base-300);
 
   & svg {
-    width: calc(var(--base) * 0.75);
-    margin-right: calc(var(--base) * 0.25);
+    width: 0.75rem;
+    margin-right: 0.25rem;
   }
 
   & span {
@@ -160,16 +160,16 @@
   .authorName {
     flex-wrap: wrap;
     align-items: center;
-    padding-bottom: calc(var(--base) * 0.25);
+    padding-bottom: 0.25rem;
   }
 
   .comments {
-    margin-left: calc(var(--base) * 0.5);
+    margin-left: 0.5rem;
   }
 
   .twitterIcon {
     width: 15px;
-    margin: 0 calc(var(--base) * 0.5);
+    margin: 0 0.5rem;
   }
 }
 
@@ -181,7 +181,7 @@
       color: var(--color-blue-600);
     }
   }
-  
+
   .twitterIcon {
     & path {
       fill: var(--color-blue-900);

--- a/src/components/Avatar/DropdownMenu/index.module.scss
+++ b/src/components/Avatar/DropdownMenu/index.module.scss
@@ -16,15 +16,15 @@
   top: 100%;
   background-color: var(--theme-elevation-50);
   color: var(--theme-elevation-900);
-  padding: var(--base);
+  padding: 1rem;
   width: 250px;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
 
   & > * {
     margin: 0;
 
     &:not(:last-child) {
-      margin-bottom: calc(var(--base) / 2);
+      margin-bottom: 0.5rem;
     }
   }
 }
@@ -32,7 +32,7 @@
 .dropdownLabel {
   @include small;
   color: var(--theme-elevation-300);
-  margin-bottom: calc(var(--base) / 2);
+  margin-bottom: 0.5rem;
 }
 
 .profileLink {
@@ -45,8 +45,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: calc(var(--base) * 1.5);
-  height: calc(var(--base) * 1.5);
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 100%;
   background-color: var(--theme-elevation-900);
   color: var(--theme-elevation-50);
@@ -54,7 +54,7 @@
   text-transform: uppercase;
   overflow: hidden;
   flex-shrink: 0;
-  margin-right: calc(var(--base) / 2);
+  margin-right: 0.5rem;
   text-overflow: ellipsis;
 }
 

--- a/src/components/Avatar/index.module.scss
+++ b/src/components/Avatar/index.module.scss
@@ -20,8 +20,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: calc(var(--base) * 1.75);
-  height: calc(var(--base) * 1.75);
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 100%;
   background-color: var(--theme-elevation-900);
   color: var(--theme-elevation-50);

--- a/src/components/BackgroundScanline/index.module.scss
+++ b/src/components/BackgroundScanline/index.module.scss
@@ -10,7 +10,7 @@
 
   .crosshair {
     position: absolute;
-    width: calc(var(--base) * 1);
+    width: 1rem;
     height: auto;
     color: var(--theme-elevation-1000);
     opacity: 0.5;
@@ -18,23 +18,23 @@
   }
 
   .crosshairTopLeft {
-    top: calc(var(--base) * -0.5);
-    left: calc(var(--base) * -0.5);
+    top: -.5rem;
+    left: -.5rem;
   }
 
   .crosshairBottomLeft {
-    bottom: calc(var(--base) * -0.5);
-    left: calc(var(--base) * -0.5);
+    bottom: -.5rem;
+    left: -.5rem;
   }
 
   .crosshairTopRight {
-    top: calc(var(--base) * -0.5);
-    right: calc(var(--base) * -0.5);
+    top: -.5rem;
+    right: -.5rem;
   }
 
   .crosshairBottomRight {
-    bottom: calc(var(--base) * -0.5);
-    right: calc(var(--base) * -0.5);
+    bottom: -.5rem;
+    right: -.5rem;
   }
 }
 

--- a/src/components/Banner/index.module.scss
+++ b/src/components/Banner/index.module.scss
@@ -1,8 +1,8 @@
 @use '@scss/common.scss' as *;
 
 .banner {
-  padding: calc(var(--base) * 2);
-  margin: calc(var(--base) * 1.5) 0;
+  padding: 2rem;
+  margin: 1.5rem 0;
   display: flex;
 
   a,
@@ -21,7 +21,7 @@
   color: var(--theme-blue-text);
   background-color: var(--theme-blue-bg);
   border-bottom: 1px solid var(--theme-blue-border);
-  
+
   :local(.icon path) {
     stroke: var(--theme-blue-bg);
   }
@@ -31,7 +31,7 @@
   color: var(--theme-orange-text);
   background-color: var(--theme-orange-bg);
   border-bottom: 1px solid var(--theme-orange-border);
-  
+
   :local(.icon path) {
     stroke: var(--theme-orange-bg);
   }
@@ -41,7 +41,7 @@
   color: var(--theme-red-text);
   background-color: var(--theme-red-bg);
   border-bottom: 1px solid var(--theme-red-border);
-  
+
   :local(.icon path) {
     stroke: var(--theme-red-bg);
   }
@@ -77,11 +77,11 @@
   background-color: currentColor;
   border-radius: 50%;
   flex-shrink: 0;
-  margin: 5px var(--base) 0 0;
-  width: var(--base);
-  height: var(--base);
+  margin: 5px 1rem 0 0;
+  width: 1rem;
+  height: 1rem;
   padding: 4px;
-  
+
   path {
     stroke: var(--color-base-800);
     stroke-width: 2px;

--- a/src/components/BlockWrapper/index.module.scss
+++ b/src/components/BlockWrapper/index.module.scss
@@ -17,7 +17,7 @@
 
   &.padding-top {
     &-hero {
-      --wrapper-padding-top: calc(var(--base) * 2);
+      --wrapper-padding-top: 2rem;
 
       &.setPadding {
         padding-top: calc(var(--wrapper-padding-top) + var(--page-padding-top));
@@ -25,10 +25,10 @@
     }
 
     &-large {
-      --wrapper-padding-top: calc(var(--base) * 8);
+      --wrapper-padding-top: 8rem;
 
       @include mid-break {
-        --wrapper-padding-top: calc(var(--base) * 5);
+        --wrapper-padding-top: 5rem;
       }
 
       &.setPadding {
@@ -37,10 +37,10 @@
     }
 
     &-small {
-      --wrapper-padding-top: calc(var(--base) * 4);
+      --wrapper-padding-top: 4rem;
 
       @include mid-break {
-        --wrapper-padding-top: calc(var(--base) * 2.5);
+        --wrapper-padding-top: 2.5rem;
       }
 
       &.setPadding {
@@ -51,10 +51,10 @@
 
   &.padding-bottom {
     &-large {
-      --wrapper-padding-bottom: calc(var(--base) * 8);
+      --wrapper-padding-bottom: 8rem;
 
       @include mid-break {
-        --wrapper-padding-bottom: calc(var(--base) * 5);
+        --wrapper-padding-bottom: 5rem;
       }
 
       &.setPadding {
@@ -63,10 +63,10 @@
     }
 
     &-small {
-      --wrapper-padding-bottom: calc(var(--base) * 4);
+      --wrapper-padding-bottom: 4rem;
 
       @include mid-break {
-        --wrapper-padding-bottom: calc(var(--base) * 2.5);
+        --wrapper-padding-bottom: 2.5rem;
       }
 
       &.setPadding {

--- a/src/components/Breadcrumbs/index.module.scss
+++ b/src/components/Breadcrumbs/index.module.scss
@@ -30,6 +30,6 @@ a.labelContent {
 }
 
 .divider {
-  margin: 0 calc(var(--base) * 0.5);
+  margin: 0 0.5rem;
   color: var(--theme-elevation-300);
 }

--- a/src/components/Button/index.module.scss
+++ b/src/components/Button/index.module.scss
@@ -2,7 +2,7 @@
 
 $transCurve: cubic-bezier(0.4, 0, 0.2, 1);
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .button {
   all: unset;
@@ -12,8 +12,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   position: relative;
   padding: var(--button-padding);
 
-  --button-padding: calc(var(--base) * 0.5) var(--base);
-  height: calc(var(--base) * 2.5); // match input height
+  --button-padding: 0.5rem 1rem;
+  height: 2.5rem; // match input height
 
   &:focus-visible {
     @include outline;
@@ -21,20 +21,20 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
   &:disabled {
     cursor: not-allowed;
-    opacity: .25;
+    opacity: 0.25;
   }
 }
 
 .size--pill {
   @include small;
-  line-height: calc(var(--base) * 1.25);
+  line-height: 1.25rem;
   height: unset;
   border-radius: 3px;
   padding: 0 6px;
   font-weight: bold;
 
   .spacer {
-    width: calc(var(--base) * 0.75);
+    width: 0.75rem;
   }
 
   &.appearance--default {
@@ -89,7 +89,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
     & .defaultLabel {
       position: relative;
-      padding: calc(var(--base) * 1.5) var(--base);
+      padding: 1.5rem 1rem;
       width: 100%;
       transition: transform var(--animation-speed) $curve;
 
@@ -118,7 +118,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     }
 
     & .hoverLabel {
-      padding: calc(var(--base) * 1.5) var(--base);
+      padding: 1.5rem 1rem;
       position: absolute;
       left: 0;
       top: 0;
@@ -139,7 +139,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     }
 
     .content {
-      padding: calc(var(--base) * 1.5);
+      padding: 1.5rem;
 
       .label {
         margin: 0;
@@ -152,7 +152,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     }
 
     .cmsFormSubmitButtonContent {
-      padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+      padding: 1.5rem 2rem;
     }
 
     &:hover {
@@ -178,21 +178,21 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
     @include mid-break {
       .content {
-        padding: calc(var(--base) * 1.5) var(--base);
+        padding: 1.5rem 1rem;
       }
 
       & .defaultLabel, & .hoverLabel  {
-        padding: calc(var(--base) * 1.5) var(--base);
+        padding: 1.5rem 1rem;
       }
 
       .cmsFormSubmitButtonContent {
-        padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+        padding: 1.5rem 1rem;
       }
     }
   }
 
   &--large {
-    font-size: calc(var(--base) * 2);
+    font-size: 2rem;
   }
 
   &--primary {
@@ -360,8 +360,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .spacer {
-  width: calc(var(--base) * .75);
-  height: var(--base);
+  width: 0.75rem;
+  height: 1rem;
 }
 
 .icon {

--- a/src/components/CMSForm/Label/index.module.scss
+++ b/src/components/CMSForm/Label/index.module.scss
@@ -2,10 +2,10 @@
 
 .label {
   display: block;
-  margin-bottom: calc(var(--base) * 0.5);
+  margin-bottom: 0.5rem;
   color: var(--theme-elevation-650);
   line-height: 1;
-  font-size: var(--base);
+  font-size: 1rem;
   align-self: flex-end;
   display: flex;
   width: 100%;
@@ -13,14 +13,14 @@
 
 .required {
   color: var(--color-error-500);
-  margin: 0 calc(var(--base) * 0.25);
+  margin: 0 0.25rem;
 }
 
 .labelWithActions {
   width: 100%;
   display: flex;
   align-items: center;
-  margin-bottom: calc(var(--base) * 0.5);
+  margin-bottom: 0.5rem;
   display: inline-flex;
   width: 100%;
 
@@ -33,7 +33,7 @@
   display: flex;
   margin-left: auto;
   align-items: center;
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
 }
 
 .noMargin {

--- a/src/components/CMSForm/Width/index.module.scss
+++ b/src/components/CMSForm/Width/index.module.scss
@@ -1,8 +1,8 @@
 @use '@scss/common' as *;
 
 .width {
-  padding-left: calc(var(--base) / 2);
-  padding-right: calc(var(--base) / 2);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 
   @include mid-break {
     width: 100% !important;

--- a/src/components/CMSForm/fields.module.scss
+++ b/src/components/CMSForm/fields.module.scss
@@ -1,7 +1,7 @@
 @use "@scss/common" as *;
 
 .message {
-  padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+  padding: 1.5rem 2rem;
 
   &::before {
     content: '';
@@ -15,6 +15,6 @@
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+    padding: 1.5rem 1rem;
   }
 }

--- a/src/components/CMSForm/fields/Checkbox/index.module.scss
+++ b/src/components/CMSForm/fields/Checkbox/index.module.scss
@@ -5,8 +5,8 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding: calc(var(--base) * 1.75) calc(var(--base) * 2);
-  
+  padding: 1.75rem 2rem;
+
   &::before {
     content: '';
     width: calc(100% - 2px);
@@ -25,22 +25,22 @@
     cursor: pointer;
     font-size: 1rem;
     color: var(--color-text);
-  
+
     &:disabled {
       color: var(--theme-elevation-500);
     }
-  
+
     &:focus,
     &:active {
       outline: none;
     }
-  
+
     &:focus-visible {
       .input {
         @include outline;
       }
     }
-  
+
     &:hover {
       :local() {
         .icon {
@@ -53,46 +53,46 @@
   .errorLabel {
     margin: 0;
   }
-  
+
   .htmlInput {
     position: absolute;
     top: 0;
     left: 0;
     opacity: 0;
   }
-  
+
   .input {
     @include shared.formInput;
     padding: 0;
     line-height: 0;
     position: relative;
-    width: calc(var(--base) * 1);
-    height: calc(var(--base) * 1);
-    min-width: calc(var(--base) * 1);
-    min-height: calc(var(--base) * 1);
-    margin-right: calc(var(--base) / 2);
+    width: 1rem;
+    height: 1rem;
+    min-width: 1rem;
+    min-height: 1rem;
+    margin-right: 0.5rem;
     margin-bottom: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: all 0.3s ease;
   }
-  
+
   .icon {
     opacity: 0;
     transition: all 0.3s ease;
   }
-  
+
   .label {
     cursor: pointer;
     margin: 0;
     color: var(--text-dark);
-    margin-right: calc(var(--base) * 0.75);
+    margin-right: 0.75rem;
     transition: all 0.3s ease;
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.75) calc(var(--base) * 1);
+    padding: 1.75rem 1rem;
   }
 }
 

--- a/src/components/CMSForm/fields/Select/index.module.scss
+++ b/src/components/CMSForm/fields/Select/index.module.scss
@@ -19,14 +19,14 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    left: calc(var(--base) * 2);
+    left: 2rem;
     display: flex;
     align-items: center;
     pointer-events: none;
     transition: all 0.3s ease;
 
     @include mid-break {
-      left: calc(var(--base) * 1);
+      left: 1rem;
     }
   }
 
@@ -40,7 +40,7 @@
     pointer-events: none;
     font-weight: 400;
     color: var(--text-dark);
-    margin-right: calc(var(--base) * 0.75);
+    margin-right: 0.75rem;
     z-index: 1;
   }
 }
@@ -51,10 +51,10 @@
   :global {
     div.rs__control {
       @include shared.formInput;
-      padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+      padding: 1.5rem 2rem;
 
       @include mid-break {
-        padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+        padding: 1.5rem 1rem;
       }
     }
 
@@ -106,21 +106,21 @@
     .rs__indicators {
       position: absolute;
       top: 50%;
-      right: calc(var(--base) * 2);
+      right: 2rem;
       transform: translate3d(0, -50%, 0);
-      
+
       .arrow {
         transform: rotate(90deg);
       }
 
       @include mid-break {
-        right: var(--base);
+        right: 1rem;
       }
     }
 
     .rs__indicator {
       padding: 0px 4px;
-      
+
       svg path {
         fill: var(--theme-elevation-700);
       }
@@ -153,12 +153,12 @@
     }
 
     .rs__group-heading {
-      margin-bottom: calc(var(--base) / 2);
+      margin-bottom: 0.5rem;
     }
 
     .rs__option {
       font-size: 1rem;
-      padding: calc(var(--base) * 1) calc(var(--base) * 2);
+      padding: 1rem 2rem;
       background-color: #101010;
 
       &--is-focused {
@@ -172,7 +172,7 @@
       }
 
       @include mid-break {
-        padding: calc(var(--base) * 1) calc(var(--base) * 1);
+        padding: 1rem 1rem;
       }
     }
 
@@ -184,7 +184,7 @@
     .rs__multi-value__label {
       max-width: 150px;
       color: var(--color-base-0);
-      padding: calc(var(--base) / 8) calc(var(--base) / 4);
+      padding: 0.125rem 0.25rem;
     }
 
     .rs__multi-value__remove {
@@ -204,7 +204,7 @@
 
 .description {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   color: var(--color-base-0);
 }
 
@@ -219,16 +219,16 @@
   }
 
   .selectLabel {
-    margin-right: calc(var(--base) * 0.5);
+    margin-right: 0.5rem;
   }
 
   .reactSelect {
     :global {
       div.rs__control {
-        padding: calc(var(--base) * 2) calc(var(--base) * 2) calc(var(--base) * 1) calc(var(--base) * 2);
-  
+        padding: 2rem 2rem 1rem 2rem;
+
         @include mid-break {
-          padding: calc(var(--base) * 2) calc(var(--base) * 1) calc(var(--base) * 1) calc(var(--base) * 1);
+          padding: 2rem 1rem 1rem 1rem;
         }
       }
     }

--- a/src/components/CMSForm/fields/Text/index.module.scss
+++ b/src/components/CMSForm/fields/Text/index.module.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-flex;
   flex-direction: column-reverse;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   width: 100%;
 
   &::before {
@@ -23,14 +23,14 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    left: calc(var(--base) * 2);
+    left: 2rem;
     display: flex;
     align-items: center;
     pointer-events: none;
     transition: all 0.3s ease;
 
     @include mid-break {
-      left: calc(var(--base) * 1);
+      left: 1rem;
     }
   }
 
@@ -43,7 +43,7 @@
     display: block;
     width: unset;
     pointer-events: none;
-    margin-right: calc(var(--base) * 0.75);
+    margin-right: 0.75rem;
   }
 
   .textLabel {
@@ -56,55 +56,55 @@
   .fullWidth {
     width: 100%;
   }
-  
+
   .input {
     @include shared.formInput;
     color: var(--color-base-0);
-    padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+    padding: 1.5rem 2rem;
 
     @include mid-break {
-      padding: calc(var(--base) * 1.5) calc(var(--base) * 1);
+      padding: 1.5rem 1rem;
     }
   }
-  
+
   .showError {
     .input {
       border-left: 2px solid var(--theme-error-500);
     }
   }
-  
+
   .description {
     margin: 0;
   }
-  
+
   .tooltipButton {
     width: 100%;
     height: 100%;
   }
-  
+
   .type--hidden {
     display: none;
   }
-  
+
   .iconWrapper {
     position: absolute;
     top: 50%;
-    right: calc(var(--base) / 1);
+    right: 1rem;
     transform: translate3d(0, -50%, 0);
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
   }
-  
+
   .icon {
     display: flex;
     align-items: center;
     justify-content: center;
-    height: calc(var(--base) / 2);
-    width: calc(var(--base) / 2);
+    height: 0.5rem;
+    width: 0.5rem;
   }
-  
+
   .suffix {
     @include small;
     display: flex;
@@ -123,14 +123,14 @@
   }
 
   .actionsLabel {
-    margin-right: calc(var(--base) * 0.5);
+    margin-right: 0.5rem;
   }
 
   .input {
-    padding: calc(var(--base) * 2) calc(var(--base) * 2) calc(var(--base) * 1) calc(var(--base) * 2);
+    padding: 2rem 2rem 1rem 2rem;
 
     @include mid-break {
-      padding: calc(var(--base) * 2) calc(var(--base) * 1) calc(var(--base) * 1) calc(var(--base) * 1);
+      padding: 2rem 1rem 1rem 1rem;
     }
   }
 }

--- a/src/components/CMSForm/fields/Textarea/index.module.scss
+++ b/src/components/CMSForm/fields/Textarea/index.module.scss
@@ -19,17 +19,17 @@
 
   .errorAndLabel {
     position: absolute;
-    top: var(--base);
+    top: 1rem;
     display: flex;
     align-items: center;
     transform: translateY(25%);
-    left: calc(var(--base) * 2);
+    left: 2rem;
     transition: all 0.3s ease;
     color: var(--text-dark);
     pointer-events: none;
 
     @include mid-break {
-      left: calc(var(--base) * 1);
+      left: 1rem;
     }
   }
 
@@ -40,13 +40,13 @@
 
   .textareaLabel {
     transition: all 0.3s ease;
-    margin-right: calc(var(--base) * 0.75);
+    margin-right: 0.75rem;
     color: var(--text-dark);
   }
 
   .textarea {
     @include shared.formInput;
-    padding: calc(var(--base) * 1.5) calc(var(--base) * 2);
+    padding: 1.5rem 2rem;
     resize: vertical;
     max-width: 100%;
     min-height: 160px;
@@ -58,7 +58,7 @@
     }
 
     @include mid-break {
-      padding: calc(var(--base) * 3) var(--base) calc(var(--base) * 1.5);
+      padding: 3rem 1rem 1.5rem;
     }
   }
 
@@ -71,8 +71,8 @@
 
 .focused {
   .errorAndLabel {
-    top: min(15%, calc(var(--base) * 0.75));
-    transform: translateY(min(15%, calc(var(--base) * 0.75)));
+    top: min(15%, 0.75rem);
+    transform: translateY(min(15%, 0.75rem));
   }
 
   .textareaLabel, .errorLabel {
@@ -80,13 +80,13 @@
   }
 
   .textareaLabel {
-    margin-right: calc(var(--base) * 0.5);
+    margin-right: 0.5rem;
   }
 
   .textarea {
-    padding: calc(var(--base) * 2) calc(var(--base) * 2) calc(var(--base) * 1) calc(var(--base) * 2);
+    padding: 2rem 2rem 1rem 2rem;
     height: calc(var(--intrinsic-height) * 1px);
-    max-height: calc(var(--base) * 24);
+    max-height: 24rem;
 
     &::-webkit-resizer {
       display: none;
@@ -97,7 +97,7 @@
     }
 
     @include mid-break {
-      padding: calc(var(--base) * 3) var(--base) calc(var(--base) * 1);
+      padding: 3rem 1rem 1rem;
     }
   }
 }

--- a/src/components/CMSForm/fields/shared.scss
+++ b/src/components/CMSForm/fields/shared.scss
@@ -9,15 +9,15 @@
   border: 1px solid var(--theme-border-color);
   background: var(--theme-input-bg);
   color: var(--theme-elevation-1000);
-  font-size: var(--base);
-  height: calc(var(--base) * 4.5);
-  line-height: var(--base);
+  font-size: 1rem;
+  height: 4.5rem;
+  line-height: 1rem;
 
   &::-moz-placeholder,
   &::-webkit-input-placeholder {
     color: var(--theme-elevation-400);
     font-weight: normal;
-    font-size: var(--base);
+    font-size: 1rem;
   }
 
   &:hover {
@@ -42,6 +42,6 @@
 
 .description {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   color: var(--theme-elevation-400);
 }

--- a/src/components/CMSForm/index.module.scss
+++ b/src/components/CMSForm/index.module.scss
@@ -78,7 +78,7 @@
 
   .crosshair {
     position: absolute;
-    width: calc(var(--base) * 1);
+    width: 1rem;
     height: auto;
     z-index: 5;
     color: var(--theme-elevation-1000);
@@ -86,8 +86,8 @@
   }
 
   .crosshairLeft {
-    top: calc(0% + var(--base) * -0.5);
-    left: calc(0% + var(--base) * -0.5);
+    top: calc(0% - 0.5rem);
+    left: calc(0% - 0.5rem);
   }
 }
 

--- a/src/components/ChangeHeaderTheme/index.module.scss
+++ b/src/components/ChangeHeaderTheme/index.module.scss
@@ -14,7 +14,7 @@
 
 .stickyObserver {
   --observer-variance: 1px;
-  --center-of-header: calc(var(--header-height) * .5);
+  --center-of-header: calc(var(--header-height) * 0.5);
   position: sticky;
   top: calc(var(--center-of-header) - var(--observer-variance));
   margin-bottom: calc(var(--center-of-header) + var(--observer-variance));
@@ -34,7 +34,7 @@
     right:0;
     bottom: 0;
     left: 0;
-    opacity: .55;
+    opacity: 0.55;
   }
 }
 
@@ -51,7 +51,7 @@
     height: calc(var(--center-of-header) + var(--observer-variance));
     background-color: red;
     width: 100%;
-    opacity: .15;
+    opacity: 0.15;
     z-index: inherit;
   }
 }

--- a/src/components/CircleIconButton/index.module.scss
+++ b/src/components/CircleIconButton/index.module.scss
@@ -27,12 +27,12 @@
 }
 
 .label {
-  margin-left: calc(var(--base) * 0.75);
+  margin-left: 0.75rem;
 }
 
 .iconWrapper {
-  width: calc(var(--base) * 1.5);
-  height: calc(var(--base) * 1.5);
+  width: 1.5rem;
+  height: 1.5rem;
   border: 1px solid currentColor;
   border-radius: 100%;
   display: flex;

--- a/src/components/Code/index.module.scss
+++ b/src/components/Code/index.module.scss
@@ -1,15 +1,15 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .codeWrap {
-  min-height: calc(var(--base) * 24);
+  min-height: 24rem;
   margin: auto 0;
   display: flex;
   align-items: center;
 
   @include mid-break {
-    margin: 0 var(--base);
+    margin: 0 1rem;
 
     :global(.blog-wrap) & {
       margin: 0;
@@ -23,7 +23,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .code {
   -webkit-text-size-adjust: 100%;
-  padding: calc(var(--base) * 2);
+  padding: 2rem;
   padding-right: 0;
   font-size: 14px;
   line-height: 1.5;
@@ -149,7 +149,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   }
 
   @include mid-break {
-    padding: var(--base);
+    padding: 1rem;
     font-size: 13px;
 
     :global {
@@ -177,8 +177,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   display: inline-block;
   text-align: right;
   color: var(--color-base-750);
-  padding-right: calc(var(--base) * 2);
-  width: calc(var(--base) * 3);
+  padding-right: 2rem;
+  width: 3rem;
 
   @include mid-break {
     display: none;

--- a/src/components/CodeBlip/Button/index.module.scss
+++ b/src/components/CodeBlip/Button/index.module.scss
@@ -1,6 +1,6 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 :global(.group-active) {
   .button {
@@ -14,14 +14,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   aspect-ratio: 1 / 1;
   width: auto;
   height: auto;
-  padding: calc(var(--base) * 0.75);
+  padding: 0.75rem;
   border-radius: 100%;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: calc(var(--base) * -0.8);
-  right: calc(var(--base) * -3.5);
+  top: -0.8rem;
+  right: -3.5rem;
   z-index: 2;
   transform: scale(0);
   opacity: 0;
@@ -123,7 +123,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   }
 
   svg {
-    width: calc(var(--base) * 1.35);
+    width: 1.35rem;
     height: auto;
 
     border: 1px solid var(--color-base-0);
@@ -157,7 +157,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .codeFeature {
   position: absolute;
-  right: calc(var(--base) * -2);
+  right: -2rem;
   bottom: 0;
   z-index: 1;
 
@@ -168,14 +168,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     visibility: hidden;
     width: max-content;
     min-width: fit-content;
-    padding: calc(var(--base) * 1);
+    padding: 1rem;
     background: var(--theme-elevation-0);
-    max-width: max(400%, calc(var(--base) * 20));
+    max-width: max(400%, 20rem);
     left: 0;
     z-index: 3;
 
     @include small-break {
-      max-width: max(90vw, calc(var(--base) * 4));
+      max-width: max(90vw, 4rem);
     }
 
     &.active {

--- a/src/components/CodeBlip/Modal/index.module.scss
+++ b/src/components/CodeBlip/Modal/index.module.scss
@@ -1,6 +1,6 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .modal {
   position: absolute;
@@ -11,12 +11,12 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   height: 100%;
   background: rgba(10, 10, 10, 0.51);
   backdrop-filter: blur(22px);
-  padding: calc(var(--base) * 5);
+  padding: 5rem;
   overscroll-behavior: contain;
   overflow: auto;
 
   @include mid-break {
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
   }
 
   &::before {
@@ -33,7 +33,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .label {
   @include h6;
   text-transform: uppercase;
-  margin-bottom: calc(var(--base) * 1.75);
+  margin-bottom: 1.75rem;
 
   @include data-theme-selector('dark') {
     color: var(--color-base-0);
@@ -59,9 +59,9 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
   color: var(--color-base-400);
   position: absolute;
-  right: calc(var(--base) * 3);
-  top: calc(var(--base) * 3);
-  padding: calc(var(--base) * 1.25);
+  right: 3rem;
+  top: 3rem;
+  padding: 1.25rem;
   border: 1px solid var(--color-base-400);
   border-radius: 100%;
   aspect-ratio: 1/1;
@@ -69,19 +69,19 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   transition: 350ms $curve;
 
   @include mid-break {
-    right: calc(var(--base) * 2);
-    top: calc(var(--base) * 2);
-    padding: calc(var(--base) * .5);
+    right: 2rem;
+    top: 2rem;
+    padding: 0.5rem;
 
     svg {
       height: auto;
-      width: calc(var(--base) * .75);
+      width: 0.75rem;
     }
   }
 
   svg {
     height: auto;
-    width: calc(var(--base) * 1.25);
+    width: 1.25rem;
   }
 
   &:hover {

--- a/src/components/CreatePayloadApp/index.module.scss
+++ b/src/components/CreatePayloadApp/index.module.scss
@@ -13,7 +13,7 @@
 }
 
 .cta {
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
   position: relative;
   @include code;
   font-size: 1.125em;
@@ -60,7 +60,7 @@
 
 .background {
   background: var(--color-base-900);
-  padding: var(--base);
+  padding: 1rem;
 }
 
 .copyButton {

--- a/src/components/DiscordGitBody/index.module.scss
+++ b/src/components/DiscordGitBody/index.module.scss
@@ -19,12 +19,12 @@
 
 .GitHub {
   & p {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }
 
 .body {
-  margin-top: var(--base);
+  margin-top: 1rem;
   overflow-wrap: anywhere;
 
   :global(.ts) {
@@ -57,13 +57,13 @@
   }
 
   & hr {
-    margin: var(--base) 0;
+    margin: 1rem 0;
   }
 
   & code,
   & pre {
     @include code;
-    line-height: var(--base);
+    line-height: 1rem;
     -moz-tab-size: 4;
     -o-tab-size: 4;
     tab-size: 4;
@@ -71,12 +71,12 @@
     -moz-hyphens: none;
     -ms-hyphens: none;
     hyphens: none;
-    padding: calc(var(--base) * 0.15);
+    padding: 0.15rem;
   }
 
   & pre {
     background-color: var(--color-base-950);
-    padding: calc(var(--base) * 1.5);
+    padding: 1.5rem;
 
     code {
       background: none;
@@ -100,15 +100,15 @@
   }
 
   & h4 {
-    font-size: calc(var(--base) * 1.35);
+    font-size: 1.35rem;
   }
 
   & h5 {
-    font-size: calc(var(--base) * 1.25);
+    font-size: 1.25rem;
   }
 
   & h6 {
-    font-size: calc(var(--base) * 1.15);
+    font-size: 1.15rem;
   }
 
   & a {
@@ -118,7 +118,7 @@
 
   & blockquote {
     margin-left: 0;
-    padding-left: var(--base);
+    padding-left: 1rem;
     border-left: 2px solid var(--theme-elevation-300);
   }
 

--- a/src/components/DiscordGitCTA/index.module.scss
+++ b/src/components/DiscordGitCTA/index.module.scss
@@ -7,7 +7,7 @@
   flex-direction: column;
   text-align: left;
   justify-content: space-between;
-  padding: calc(var(--base)*1.5) var(--base);
+  padding: 1.5rem 1rem;
   margin: 0;
   background-color: transparent;
   border-bottom: 1px solid var(--grid-line-dark);
@@ -73,13 +73,13 @@
 .discordButton {
   display: flex;
   justify-content: space-between;
-  margin: var(--base) 0 0 0;
+  margin: 1rem 0 0 0;
   width: 100%;
   align-items: center;
   height: 26px;
 
   & img {
-    border-radius: .25em; // matches github button
+    border-radius: 0.25em; // matches github button
     height: 26px;
   }
 }
@@ -88,7 +88,7 @@
   display: flex;
   flex-direction: column;
   line-height: 1.2;
-  padding: calc(var(--base)*1.5) var(--base);
+  padding: 1.5rem 1rem;
 
   .license {
     margin: 0;

--- a/src/components/DiscordGitComments/index.module.scss
+++ b/src/components/DiscordGitComments/index.module.scss
@@ -2,29 +2,29 @@
 
 .comments {
   padding: 0;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   list-style: none;
 
   @include mid-break {
-    margin-bottom: calc(var(--base)*2);
+    margin-bottom: 2rem;
   }
 }
 
 .comment {
-  margin: calc(var(--base) * 2) 0;
+  margin: 2rem 0;
 }
 
 .comment,
 .reply {
   border: 1px solid var(--theme-border-color);
-  padding: calc(var(--base) * 2) calc(var(--base) * 4);
+  padding: 2rem 4rem;
   line-height: 1.5;
 
   @include mid-break {
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding: var(--base);
+    padding: 1rem;
   }
 }
 
@@ -52,7 +52,7 @@
 .replyCount {
   @include uppercaseLabel;
   color: var(--color-base-500);
-  padding-top: calc(var(--base) * 1.5);
+  padding-top: 1.5rem;
 }
 
 .answer {
@@ -66,7 +66,7 @@
 
 .answerHeader {
   position: relative;
-  padding: calc(var(--base) * 1.5) calc(var(--base) * 4);
+  padding: 1.5rem 4rem;
   background-color: var(--theme-blue-100);
 
   & h6 {
@@ -75,21 +75,21 @@
   }
 
   .selectedBy {
-    font-size: calc(var(--base) * 0.65);
+    font-size: 0.65rem;
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5) var(--base);
+    padding: 1.5rem 1rem;
   }
 }
 
 .answerBody {
-  padding: calc(var(--base) * 1.5) calc(var(--base) * 4);
+  padding: 1.5rem 4rem;
   color: var(--theme-text);
   background-color: var(--theme-blue-50);
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5) var(--base);
+    padding: 1.5rem 1rem;
   }
 }
 
@@ -97,7 +97,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   width: 100%;
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include large-break {
     grid-template-columns: 1fr;
@@ -138,11 +138,11 @@
   }
 
   .comment {
-    margin: var(--base) 0;
+    margin: 1rem 0;
   }
 
   .reply {
-    padding: var(--base);
-    padding-left: calc(var(--base)*1.5);
+    padding: 1rem;
+    padding-left: 1.5rem;
   }
 }

--- a/src/components/DiscordGitIntro/index.module.scss
+++ b/src/components/DiscordGitIntro/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .breadcrumbWrap {
-  margin: 0 0 var(--base) 0;
+  margin: 0 0 1rem 0;
 }
 
 .breadcrumb {
@@ -19,22 +19,22 @@
 
 .divider {
   height: 1px;
-  margin: calc(var(--base) * 4) calc(var(--base) * -4);
+  margin: 4rem -4rem;
   background-color: var(--theme-border-color);
 
 
   @include mid-break {
-    margin: calc(var(--base) * 2) calc(var(--base) * -1);
+    margin: 2rem -1rem;
   }
 }
 
 .authorDetails {
   display: flex;
   align-items: center;
-  padding: var(--base) 0 var(--base) 0;
+  padding: 1rem 0 1rem 0;
 
   @include mid-break {
-    padding: calc(var(--base) * 0.5) 0;
+    padding: 0.5rem 0;
   }
 }
 
@@ -42,7 +42,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   width: 100%;
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include large-break {
     grid-template-columns: 1fr;

--- a/src/components/DiscordUsersPill/index.module.scss
+++ b/src/components/DiscordUsersPill/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .pill {
-  height: calc(var(--base) * 2);
+  height: 2rem;
   display: flex;
   align-items: center;
   border: 1px solid var(--color-base-650);
@@ -11,7 +11,7 @@
 
 .leftPill {
   @include small;
-  padding: calc(var(--base) * .25) calc(var(--base) * .5);
+  padding: 0.25rem 0.5rem;
   background-color: var(--color-base-850);
   color: var(--color-base-200);
   height: 28px;
@@ -27,7 +27,7 @@
   @include small;
   position: relative;
   margin: 0;
-  padding: calc(var(--base) * .25) calc(var(--base) * .5);
+  padding: 0.25rem 0.5rem;
   background-color: #5865F2; // discord color https://discord.com/branding
   color: var(--color-base-0);
   height: 28px;

--- a/src/components/Drawer/index.module.scss
+++ b/src/components/Drawer/index.module.scss
@@ -22,7 +22,7 @@
 
 .content {
   opacity: 0;
-  transform: translateX(#{calc(var(--base) * 4)});
+  transform: translateX(#{4rem});
   position: relative;
   z-index: 2;
   width: 100%;
@@ -36,10 +36,10 @@
   z-index: 1;
   overflow: auto;
   height: 100%;
-  padding: calc(var(--base) * 4);
+  padding: 4rem;
 
   @include mid-break {
-    padding:  calc(var(--base) * 2) var(--base) 0;
+    padding:  2rem 1rem 0;
   }
 }
 
@@ -84,7 +84,7 @@
 .header {
   display: flex;
   align-items: flex-start;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   width: 100%;
 }
 
@@ -93,7 +93,7 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
-  gap: var(--base);
+  gap: 1rem;
 }
 
 .description {
@@ -102,7 +102,7 @@
 }
 
 .title {
-  margin: 0 var(--base) 0 0;
+  margin: 0 1rem 0 0;
   flex-grow: 1;
 }
 
@@ -120,7 +120,7 @@
   &:focus-visible {
     @include outline;
   }
-  
+
   @include mid-break {
     top: 2px;
   }
@@ -134,7 +134,7 @@
 
 .size-m {
   .contentChildren {
-    padding: calc(var(--base) * 3);
+    padding: 3rem;
   }
 
   .close {
@@ -142,9 +142,9 @@
   }
 }
 
-.size-s {  
+.size-s {
   .contentChildren {
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
   }
 
   .close {
@@ -153,11 +153,11 @@
 
   @include mid-break {
     .contentChildren {
-      padding: calc(var(--base) * 1);
+      padding: 1rem;
     }
 
     .header {
-      margin-bottom: calc(var(--base) * 1);
+      margin-bottom: 1rem;
     }
   }
 }

--- a/src/components/DropdownMenu/MenuContent/index.module.scss
+++ b/src/components/DropdownMenu/MenuContent/index.module.scss
@@ -3,15 +3,15 @@
 .menuContent {
   @include small;
   position: absolute;
-  top: calc(100% + calc(var(--base)));
+  top: calc(100% + 1rem);
   left: 50%;
   z-index: 2;
   transform: translate3d(-50%, -20%, 0);
-  padding: calc(var(--base) * .75);
+  padding: 0.75rem;
   color: var(--theme-text);
   white-space: nowrap;
   background-color: var(--theme-elevation-150);
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }

--- a/src/components/DropdownMenu/index.module.scss
+++ b/src/components/DropdownMenu/index.module.scss
@@ -24,7 +24,7 @@
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: calc(var(--base) / 2);
+  padding: 0.5rem;
   color: var(--theme-elevation-500);
 
   &:hover {

--- a/src/components/FeaturedBlogPost/index.module.scss
+++ b/src/components/FeaturedBlogPost/index.module.scss
@@ -3,9 +3,9 @@
 .wrapper {
   display: block;
   position: relative;
-  padding: calc(var(--base) * 2.5);
+  padding: 2.5rem;
   text-decoration: none;
-  margin-bottom: calc(var(--base) * 5.4);
+  margin-bottom: 5.4rem;
 
   .scanline {
     transition: background-color var(--trans-default) linear;
@@ -23,7 +23,7 @@
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 1.5);
+    padding: 1.5rem;
   }
 
   &:hover {
@@ -73,15 +73,15 @@
 
 .title {
   margin: 0;
-  margin-bottom: calc(var(--base) * 1.2);
+  margin-bottom: 1.2rem;
 }
 
 .meta {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 1);
+  gap: 1rem;
   opacity: 0.5;
-  margin-bottom: calc(var(--base) * 1.2);
+  margin-bottom: 1.2rem;
 
   time {
     @include body;
@@ -99,12 +99,12 @@
 .media {
   flex-shrink: 1;
   max-width: 50%;
-  padding-right: calc(var(--base) * 2.5);
+  padding-right: 2.5rem;
 
   @include mid-break {
     width: 100%;
     padding: 0;
-    margin-bottom: calc(var(--base) * 2.5);
+    margin-bottom: 2.5rem;
     max-width: 100%;
   }
 }
@@ -116,26 +116,26 @@
 .crosshair {
   position: absolute;
   height: auto;
-  width: calc(var(--base) * 1.25);
+  width: 1.25rem;
   opacity: 0.75;
 }
 
 .crosshairTopLeft {
-  top: calc(var(--base) * -0.625);
-  left: calc(var(--base) * -0.625);
+  top: -.625rem;
+  left: -.625rem;
 }
 
 .crosshairTopRight {
-  top: calc(var(--base) * -0.625);
-  right: calc(var(--base) * -0.625);
+  top: -.625rem;
+  right: -.625rem;
 }
 
 .crosshairBottomLeft {
-  bottom: calc(var(--base) * -0.625);
-  left: calc(var(--base) * -0.625);
+  bottom: -.625rem;
+  left: -.625rem;
 }
 
 .crosshairBottomRight {
-  bottom: calc(var(--base) * -0.625);
-  right: calc(var(--base) * -0.625);
+  bottom: -.625rem;
+  right: -.625rem;
 }

--- a/src/components/FileAttachment/index.module.scss
+++ b/src/components/FileAttachment/index.module.scss
@@ -4,7 +4,7 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   width: fit-content;
-  margin-top: var(--base);
+  margin-top: 1rem;
 
   @include large-break {
     grid-template-columns: 1fr;
@@ -19,16 +19,16 @@
   text-decoration: none;
 
   &:nth-child(even) {
-    margin-left: calc(var(--base) * 1.75);
+    margin-left: 1.75rem;
   }
 
   &:nth-child(2n+3) {
-    margin-top: calc(var(--base) * 1.75);
+    margin-top: 1.75rem;
   }
 
   @include large-break {
     &:not(:first-child) {
-      margin-top: calc(var(--base) * 1.75);
+      margin-top: 1.75rem;
       margin-left: 0;
     }
   }
@@ -45,14 +45,14 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--base);
+  padding: 1rem;
   background-color: var(--color-base-1000);
   border: 1px solid var(--color-base-650);
-  font-size: calc(var(--base) * 0.75);
-  
+  font-size: 0.75rem;
+
   & svg {
-    width: calc(var(--base) * 2);
-    margin-left: calc(var(--base) * 0.5);
+    width: 2rem;
+    margin-left: 0.5rem;
   }
 
   &:hover {
@@ -66,8 +66,8 @@
   }
 
   @include small-break {
-    padding: calc(var(--base) * 1);
-    font-size: calc(var(--base) * 0.75);
+    padding: 1rem;
+    font-size: 0.75rem;
   }
 }
 

--- a/src/components/Footer/index.module.scss
+++ b/src/components/Footer/index.module.scss
@@ -1,21 +1,21 @@
 @use '@scss/common' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .footer {
   position: relative;
   background: var(--color-base-1000);
-  padding-top: calc(var(--base) * 8);
-  padding-bottom: calc(var(--base) * 7.5);
+  padding-top: 8rem;
+  padding-bottom: 7.5rem;
   overflow: hidden;
 
   @include mid-break {
-    padding-top: calc(var(--base) * 4);
-    padding-bottom: calc(var(--base) * 7.5);
+    padding-top: 4rem;
+    padding-bottom: 7.5rem;
   }
 
   .grid {
-    grid-row-gap: calc(var(--base) * 3);
+    grid-row-gap: 3rem;
   }
 }
 
@@ -30,20 +30,20 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .colHeader {
   @include h6;
-  margin-bottom: calc(var(--base) * 4.5);
+  margin-bottom: 4.5rem;
   display: inline-flex;
   align-items: flex-end;
   text-transform: uppercase;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 }
 
 .footer .link {
   @include body;
   display: block;
-  margin-bottom: calc(var(--base) * .15);
+  margin-bottom: 0.15rem;
   color: var(--color-base-0);
 
   &:hover {
@@ -61,13 +61,13 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: calc(var(--base) * 1);
+  gap: 1rem;
 }
 
 .subscribeAction {
   display: flex;
-  margin-top: calc(var(--base) * 1);
-  margin-bottom: calc(var(--base) * 2);
+  margin-top: 1rem;
+  margin-bottom: 2rem;
 }
 
 .subscribeDesc {
@@ -89,7 +89,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .emailInput input {
   @include body;
-  padding: var(--base) calc(var(--base) * 1.5);
+  padding: 1rem 1.5rem;
   background: var(--color-base-1000);
   border-color: var(--grid-line-dark);
   border-left: none;
@@ -112,7 +112,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   color: var(--color-base-300);
   transform: rotate(45deg);
   transition: transform 350ms $curve;
-  height: calc(var(--base) * 0.6);
+  height: 0.6rem;
   width: auto;
 }
 
@@ -121,17 +121,17 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   cursor: pointer;
   display: block;
   position: absolute;
-  right: calc(var(--base) * 1.5);
-  top: calc(50% - var(--base) * 0.6);
+  right: 1.5rem;
+  top: calc(50% - 0.6rem);
 }
 
 .socialLinks {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--base);
+  gap: 1rem;
   max-width: 100%;
   align-items: center;
-  margin-bottom: calc(var(--base) * 3);
+  margin-bottom: 3rem;
 }
 
 .socialIconLink {
@@ -139,18 +139,18 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   transition: opacity 350ms $curve;
 
   &:hover {
-    opacity: .75;
+    opacity: 0.75;
   }
 
   & svg {
     height: auto;
-    width: calc( var(--base) * 1.6);
+    width: 1.6rem;
   }
 }
 
 .selectContainer {
-  --theme-icon-width: calc(var(--base) * 2);
-  --theme-switcher-icon-width: calc(var(--base) * 2);
+  --theme-icon-width: 2rem;
+  --theme-switcher-icon-width: 2rem;
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -165,8 +165,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     border-top: 1px solid var(--grid-line-dark);
     border-bottom: 1px solid var(--grid-line-dark);
     width: 100%;
-    padding: var(--base) calc(var(--base) * 1.5);
-    padding-left: calc(var(--base) * 1.5 + var(--theme-switcher-icon-width));
+    padding: 1rem 1.5rem;
+    padding-left: calc(1.5rem + var(--theme-switcher-icon-width));
 
   }
   &::before {
@@ -183,10 +183,10 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .switcherIcon {
   display: inline-flex;
-  height: var(--base);
+  height: 1rem;
   justify-content: center;
   position: absolute;
-  margin-left: calc(var(--base) * 1.25);
+  margin-left: 1.25rem;
 }
 
 .themeIcon {
@@ -195,6 +195,6 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .upDownChevronIcon {
   width: var(--theme-switcher-icon-width);
-  right: calc(var(--base) * 0.75);
+  right: 0.75rem;
   pointer-events: none;
 }

--- a/src/components/GithubStarsPill/index.module.scss
+++ b/src/components/GithubStarsPill/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common' as *;
 
 .pill {
-  height: calc(var(--base) * 2);
+  height: 2rem;
   display: flex;
   align-items: center;
   height: 30px;
@@ -10,11 +10,11 @@
 }
 
 .leftPill {
-  padding: calc(var(--base) * .25) calc(var(--base) * .5);
+  padding: 0.25rem 0.5rem;
   background-color: var(--color-base-850);
   color: var(--color-base-200);
   display: flex;
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
   height: 28px;
 
   svg {
@@ -36,7 +36,7 @@
   @include small;
   position: relative;
   margin: 0;
-  padding: calc(var(--base) * .25) calc(var(--base) * .5);
+  padding: 0.25rem 0.5rem;
   background-color: var(--color-base-950);
   color: white;
   height: 28px;

--- a/src/components/Header/DesktopNav/index.module.scss
+++ b/src/components/Header/DesktopNav/index.module.scss
@@ -1,6 +1,6 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .desktopNav {
   position: relative;
@@ -99,7 +99,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   align-items: center;
 
   & > *:not(:last-child) {
-    margin-right: calc(var(--base) * 1);
+    margin-right: 1rem;
   }
 }
 
@@ -122,7 +122,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   flex-grow: 1;
   display: flex;
   flex-direction: row;
-  gap: calc(var(--base) * 1.5);
+  gap: 1.5rem;
 }
 
 .tab {
@@ -145,9 +145,9 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .tabArrow, .linkArrow {
-  margin-left: calc(var(--base) * 0.5);
-  width: calc(var(--base) * 0.5);
-  height: calc(var(--base) * 0.5);
+  margin-left: 0.5rem;
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 .underline {
@@ -175,7 +175,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   left: 0;
   width: 100%;
   pointer-events: none;
-  padding: calc(var(--base) * 2.5) var(--gutter-h) 0 var(--gutter-h);
+  padding: 2.5rem var(--gutter-h) 0 var(--gutter-h);
   transition: opacity var(--trans-default) $curve;
 }
 
@@ -185,8 +185,8 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 
 .dropdownItem, .description {
   text-wrap: wrap;
-  margin-right: calc(var(--base) * 2);
-  padding-bottom: calc(var(--base) * 2.5);
+  margin-right: 2rem;
+  padding-bottom: 2.5rem;
   transition: opacity var(--trans-default) $curve;
   opacity: 0;
 
@@ -248,7 +248,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .defaultLink, .defaultLinkDescription {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
   justify-content: space-between;
 }
 
@@ -269,7 +269,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .defaultLinkDescription {
-  min-height: calc(var(--base) * 5);
+  min-height: 5rem;
   @include small;
 }
 
@@ -280,7 +280,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .linkList, .featuredLink {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
+  gap: 1rem;
 }
 
 .listLabel {
@@ -326,14 +326,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .featuredLinkWrap {
   display: flex;
   flex-direction: row;
-  gap: calc(var(--base) * 2);
+  gap: 2rem;
 }
 
 .descriptionLinks {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
-  padding: calc(var(--base) * 2) 0;
+  gap: 1rem;
+  padding: 2rem 0;
 }
 
 .secondaryNavItems {
@@ -342,14 +342,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   justify-content: flex-end;
   align-items: center;
   white-space: nowrap;
-  gap: calc(var(--base) * 1.25);
+  gap: 1.25rem;
   opacity: 0;
   visibility: hidden;
   transition: all var(--trans-default) $curve;
 
   & > a {
     &:hover {
-      opacity: .8;
+      opacity: 0.8;
     }
   }
 }
@@ -373,7 +373,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   @include small;
 
   > * {
-    margin-right: calc(var(--base) * .75);
+    margin-right: 0.75rem;
 
     &:last-child {
       margin-right: 0;
@@ -384,14 +384,14 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 .github {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 0.5);
+  gap: 0.5rem;
   svg {
-    width: calc(var(--base) * 1.25);
+    width: 1.25rem;
   }
 
 
   @include large-break {
-      margin-bottom: calc(var(--base) * -0.25);
+      margin-bottom: -.25rem;
   }
 
   &:hover {

--- a/src/components/Header/Docsearch/index.module.scss
+++ b/src/components/Header/Docsearch/index.module.scss
@@ -3,7 +3,7 @@
 .docSearch {
   position: relative;
   min-width: 20px;
-  margin-left: calc(var(--base) * .75);
+  margin-left: 0.75rem;
   :global(.DocSearch-Button) {
     padding: 0;
     margin:0;

--- a/src/components/Header/MobileNav/index.module.scss
+++ b/src/components/Header/MobileNav/index.module.scss
@@ -22,7 +22,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--base) 0;
+  padding: 1rem 0;
 
   & a {
     color: var(--theme-elevation-900);
@@ -32,15 +32,15 @@
 .descriptionLinks {
   display: flex;
   flex-direction: column;
-  gap: var(--base);
-  padding: calc(var(--base) * 2) 0;
+  gap: 1rem;
+  padding: 2rem 0;
 }
 
 .descriptionLink {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: var(--base);
+  gap: 1rem;
   text-decoration: none;
 }
 
@@ -58,7 +58,7 @@
 
   > * {
     text-decoration: none;
-    margin-right: var(--base);
+    margin-right: 1rem;
     line-height: 1;
   }
 
@@ -74,20 +74,20 @@
 
 .mobileAvatar {
   @include mobile-header-break {
-    margin-left: var(--base);
+    margin-left: 1rem;
   }
 }
 
 .searchToggler {
   all: unset;
   cursor: pointer;
-  margin-right: calc(var(--base) *  .5);
+  margin-right: 0.5rem;
 }
 
 .modalToggler {
   all: unset;
   cursor: pointer;
-  margin-left: var(--base);
+  margin-left: 1rem;
   height: 100%;
   display: flex;
   align-self: center;
@@ -196,7 +196,7 @@
   font-family: var(--font-body);
   @include h4;
   letter-spacing: -0.02em;
-  padding: calc(var(--base)*1.25);
+  padding: 1.25rem;
   font-weight: 500;
   margin: 0;
   text-decoration: none;
@@ -227,7 +227,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--base) ;
+  gap: 1rem ;
   cursor: pointer;
   position: relative;
   border-top: 1px solid var(--theme-border-color);
@@ -246,7 +246,7 @@
     position: relative;
     border: 1px solid var(--theme-border-color);
     border-top: 0;
-    padding: calc(var(--base) * 1.25);
+    padding: 1.25rem;
     background-color: var(--theme-bg);
     z-index: 1;
   }
@@ -282,7 +282,7 @@
 
 .subMenuWrap {
   position: relative;
-  padding: var(--base) 0;
+  padding: 1rem 0;
   top: 0;
   bottom: 0;
   min-height: 100%;
@@ -303,27 +303,27 @@
 .featuredLinkWrap {
   @include btnReset;
   display: flex;
-  gap: calc(var(--base) * 2);
-  margin-top: calc(var(--base) * 2);
+  gap: 2rem;
+  margin-top: 2rem;
 }
 
 .featuredLinks {
   font-size: var(--font-size-body);
   text-decoration: none;
   display: flex;
-  gap: calc(var(--base) * 0.75);
+  gap: 0.75rem;
   align-items: center;
 
   & svg {
-    width: calc(var(--base) * 0.85);
-    height: calc(var(--base) * 0.85);
+    width: 0.85rem;
+    height: 0.85rem;
   }
 }
 
 .linkArrow {
-  margin-left: calc(var(--base) * 0.5);
-  width: calc(var(--base) * 0.5);
-  height: calc(var(--base) * 0.5);
+  margin-left: 0.5rem;
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 .listLabelWrap {
@@ -336,7 +336,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: 0 0 calc(var(--base) * .5) 0;
+  margin: 0 0 0.5rem 0;
 }
 
 .listWrap {
@@ -349,7 +349,7 @@
   width: 47%;
   text-decoration: none;
   font-weight: 500;
-  margin-bottom: calc(var(--base) * .5);
+  margin-bottom: 0.5rem;
 }
 
 .itemDescription {
@@ -359,7 +359,7 @@
 
 .tag {
   @include h6;
-  margin: 0 0 calc(var(--base) * 1.5) 0;
+  margin: 0 0 1.5rem 0;
   font-weight: normal;
   text-transform: uppercase;
 }

--- a/src/components/Heading/index.module.scss
+++ b/src/components/Heading/index.module.scss
@@ -2,12 +2,12 @@
 
 .headingScrollTo {
   position: absolute;
-  bottom: calc(100% + calc(var(--base) * 2));
+  bottom: calc(100% + 2rem);
   left: 0;
   width: 100%;
 
   @include mid-break {
-    bottom: calc(100% + var(--base));
+    bottom: calc(100% + 1rem);
   }
 }
 

--- a/src/components/Hero/BreadcrumbsBar/index.module.scss
+++ b/src/components/Hero/BreadcrumbsBar/index.module.scss
@@ -45,7 +45,7 @@
     border-color: var(--grid-line-dark);
   }
 
-  padding: calc(var(--base) * 1.5) 0;
+  padding: 1.5rem 0;
 
   display: flex;
   justify-content: space-between;
@@ -57,7 +57,7 @@
 
 .links {
   display: flex;
-   gap: calc(var(--base) * 1.85);
+   gap: 1.85rem;
 }
 
 .link {
@@ -72,7 +72,7 @@
 .containerMobile {
   border-top: 1px solid var(--grid-line-light);
   border-bottom: 1px solid var(--grid-line-light);
-  padding: calc(var(--base) * 0.75) 0;
+  padding: 0.75rem 0;
   display: none;
 
   @include data-theme-selector('dark') {
@@ -96,7 +96,7 @@
     list-style: none;
     display: flex;
     justify-content: space-between;
-    padding: calc(var(--base) * 0.5) 0 calc(var(--base) * .5);
+    padding: 0.5rem 0 0.5rem;
 
     &::marker, &::-webkit-details-marker {
       display: none;
@@ -111,8 +111,8 @@
       transition: transform 0.1s ease-in-out;
       transform: rotate(90deg);
       height: auto;
-      width: calc(var(--base) * 0.4);
-      margin-right: calc(var(--base) * 0.4);
+      width: 0.4rem;
+      margin-right: 0.4rem;
     }
   }
 
@@ -127,10 +127,10 @@
   left: calc(var(--gutter-h) * -1);
   width: calc(100% + var(--gutter-h) * 2);
   z-index: 1;
-  padding: calc(var(--base) * 1.5) var(--gutter-h) calc(var(--base) * 1.5);
+  padding: 1.5rem var(--gutter-h) 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1);
+  gap: 1rem;
   border-bottom: 1px solid var(--grid-line-light);
 
   @include data-theme-selector('dark') {

--- a/src/components/Hero/CenteredContent/index.module.scss
+++ b/src/components/Hero/CenteredContent/index.module.scss
@@ -11,11 +11,11 @@
 
 .label {
   margin-left: 0;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
   display: block;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 1);
+    margin-bottom: 1rem;
   }
 
    & label {
@@ -25,7 +25,7 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .links {

--- a/src/components/Hero/ContentMedia/index.module.scss
+++ b/src/components/Hero/ContentMedia/index.module.scss
@@ -2,7 +2,7 @@
 
 .wrapper {
   @include mid-break {
-    row-gap: calc(var(--base) * 2);
+    row-gap: 2rem;
   }
 
   align-items: center;
@@ -15,14 +15,14 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 9);
+  margin-bottom: 9rem;
 
   @include large-break {
-    margin-bottom: calc(var(--base) * 6);
+    margin-bottom: 6rem;
   }
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 3);
+    margin-bottom: 3rem;
   }
 }
 
@@ -52,7 +52,7 @@
 }
 
 .description {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .link {

--- a/src/components/Hero/Default/index.module.scss
+++ b/src/components/Hero/Default/index.module.scss
@@ -5,10 +5,10 @@
 }
 
 .label {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 1);
+    margin-bottom: 1rem;
   }
 
   label {
@@ -21,6 +21,6 @@
   align-items: center;
 
   @include mid-break {
-    row-gap:  calc(var(--base) * 2);
+    row-gap:  2rem;
   }
 }

--- a/src/components/Hero/FormHero/index.module.scss
+++ b/src/components/Hero/FormHero/index.module.scss
@@ -16,7 +16,7 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .contentWrapper {
@@ -29,7 +29,7 @@
 
 .description {
   @include mid-break {
-    margin-bottom: calc(var(--base) * 3);
+    margin-bottom: 3rem;
   }
 }
 

--- a/src/components/Hero/FormHero/index.tsx
+++ b/src/components/Hero/FormHero/index.tsx
@@ -68,7 +68,7 @@ export const FormHero: React.FC<
               className={[classes.scanlineDesktopWrapper, 'cols-16 start-5 cols-m-8 start-m-1']
                 .filter(Boolean)
                 .join(' ')}
-              style={{ height: `calc(${backgroundHeight}px + var(--base) * 10)` }}
+              style={{ height: `calc(${backgroundHeight}px + 10rem)` }}
             >
               <BackgroundScanline
                 className={[classes.scanline].filter(Boolean).join(' ')}

--- a/src/components/Hero/Gradient/index.module.scss
+++ b/src/components/Hero/Gradient/index.module.scss
@@ -3,7 +3,7 @@
 .wrapper {
   position: relative;
   @include mid-break {
-    row-gap: calc(var(--base) * 4);
+    row-gap: 4rem;
   }
 
   align-items: center;
@@ -33,7 +33,7 @@
 }
 
 .richText {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .contentWrapper {
@@ -74,7 +74,7 @@
 }
 
 .description {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 }
 
 .bgSquare {

--- a/src/components/Hero/Home/LogoShowcase/index.module.scss
+++ b/src/components/Hero/Home/LogoShowcase/index.module.scss
@@ -68,19 +68,19 @@
 
   .contentWrapper {
     position: absolute;
-    top: calc(var(--base) * 1.5);
-    bottom: calc(var(--base) * 1.5);
-    left: calc(var(--base) * 1.5);
-    right: calc(var(--base) * 1.5);
+    top: 1.5rem;
+    bottom: 1.5rem;
+    left: 1.5rem;
+    right: 1.5rem;
     display: flex;
     align-items: center;
     justify-content: center;
 
     @include small-break {
-      top: calc(var(--base) * 1);
-      bottom: calc(var(--base) * 1);
-      left: calc(var(--base) * 1);
-      right: calc(var(--base) * 1);
+      top: 1rem;
+      bottom: 1rem;
+      left: 1rem;
+      right: 1rem;
     }
 
     > div {
@@ -91,7 +91,7 @@
       opacity: 0;
       filter: blur(0px);
     }
-  }  
+  }
 }
 
 .logoPresent {
@@ -116,7 +116,7 @@
 
 .crosshair {
   position: absolute;
-  width: calc(var(--base) * 1);
+  width: 1rem;
   height: auto;
   z-index: 5;
   color: var(--theme-elevation-1000);
@@ -124,23 +124,23 @@
 }
 
 .crosshairBottomLeft {
-  left: calc(var(--base) * -0.5);
-  bottom: calc(var(--base) * -0.5);
+  left: -.5rem;
+  bottom: -.5rem;
 }
 
 .crosshairTopRight {
-  right: calc(var(--base) * -0.5);
-  top: calc(var(--base) * -0.5);
+  right: -.5rem;
+  top: -.5rem;
 }
 
 .crosshairFirstCell {
-  left: calc(25% + var(--base) * -0.45);
-  bottom: calc(66.666% + var(--base) * -0.55)
+  left: calc(25% -.45rem);
+  bottom: calc(66.666% -.55rem)
 }
 
 .crosshairSecondRowThirdCell {
-  left: calc(75% + var(--base) * -0.45);
-  bottom: calc(33.333% + var(--base) * -0.55);
+  left: calc(75% -.45rem);
+  bottom: calc(33.333% -.55rem);
 }
 
 :global([data-theme="dark"]) {

--- a/src/components/Hero/Home/LogoShowcase/index.module.scss
+++ b/src/components/Hero/Home/LogoShowcase/index.module.scss
@@ -134,13 +134,13 @@
 }
 
 .crosshairFirstCell {
-  left: calc(25% -.45rem);
-  bottom: calc(66.666% -.55rem)
+  left: calc(25% - .45rem);
+  bottom: calc(66.666% - .55rem)
 }
 
 .crosshairSecondRowThirdCell {
-  left: calc(75% -.45rem);
-  bottom: calc(33.333% -.55rem);
+  left: calc(75% - .45rem);
+  bottom: calc(33.333% - .55rem);
 }
 
 :global([data-theme="dark"]) {

--- a/src/components/Hero/Home/index.module.scss
+++ b/src/components/Hero/Home/index.module.scss
@@ -43,7 +43,7 @@
 
 .homeHero {
   position: relative;
-  padding-top: calc(var(--base) * 3);
+  padding-top: 3rem;
 
   @include mid-break {
     padding-top: 0;
@@ -81,13 +81,13 @@
   z-index: 1;
 
   @include mid-break {
-    left: calc(-1 * var(--base) * 10);
-    width: calc(100% + var(--base) * 10);
+    left: calc(-1 * 10rem);
+    width: calc(100% + 10rem);
   }
 
   @include small-break {
-    left: calc(-1 * var(--base) * 6);
-    width: calc(100% + var(--base) * 8);
+    left: -6rem;
+    width: calc(100% + 8rem);
   }
 }
 
@@ -104,13 +104,13 @@
   z-index: 2;
 
   @include mid-break {
-    left: calc(-1 * var(--base) * 10);
-    width: calc(100% + var(--base) * 10);
+    left: calc(-1 * 10rem);
+    width: calc(100% + 10rem);
   }
 
   @include small-break {
-    left: calc(-1 * var(--base) * 6);
-    width: calc(100% + var(--base) * 8);
+    left: -6rem;
+    width: calc(100% + 8rem);
   }
 }
 
@@ -133,13 +133,13 @@
   }
 
   @include mid-break {
-    left: calc(-1 * var(--base) * 10);
-    width: calc(100% + var(--base) * 10);
+    left: calc(-1 * 10rem);
+    width: calc(100% + 10rem);
   }
 
   @include small-break {
-    left: calc(-1 * var(--base) * 6);
-    width: calc(100% + var(--base) * 8);
+    left: -6rem;
+    width: calc(100% + 8rem);
   }
 }
 
@@ -159,26 +159,26 @@
   align-items: center;
   justify-content: space-between;
   height: 100%;
-  padding-top: calc(var(--base) * 9);
+  padding-top: 9rem;
 
   @include extra-large-break {
-    padding-top: calc(var(--base) * 8);
+    padding-top: 8rem;
   }
 
   @include large-mid-break {
-    padding-top: calc(var(--base) * 7.5);
+    padding-top: 7.5rem;
   }
 
   @include mid-plus-break {
-    padding-top: calc(var(--base) * 6.5);
+    padding-top: 6.5rem;
   }
 
   @include mid-break {
-    padding-top: calc(var(--base) * 2);
+    padding-top: 2rem;
   }
 
   @include small-break {
-    padding-top: calc(var(--base) * 1);
+    padding-top: 1rem;
   }
 
   @include mid-break {
@@ -205,15 +205,15 @@
   width: 100%;
 
   @include mid-break {
-    margin-top: calc(-1 * (var(--base) * 12));
+    margin-top: -12rem;
   }
 
   @include small-break {
-    margin-top: calc(-1 * (var(--base) * 10));
+    margin-top: -10rem;
   }
 
   @include extra-small-break {
-    margin-top: calc(-1 * (var(--base) * 8));
+    margin-top: -8rem;
   }
 }
 
@@ -246,7 +246,7 @@
   @include mid-break {
     order: 1;
     z-index: 1;
-    margin-top: calc(var(--base) * 3);
+    margin-top: 3rem;
   }
 }
 
@@ -257,31 +257,31 @@
 }
 
 .richTextHeading {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include extra-large-break {
     h1 {
-      font-size: calc(var(--base) * 3);
+      font-size: 3rem;
     }
   }
 
   @include mid-plus-break {
     h1 {
-      font-size: calc(var(--base) * 2.5);
+      font-size: 2.5rem;
     }
   }
 
   @include mid-break {
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
 
     h1 {
-      font-size: calc(var(--base) * 3);
+      font-size: 3rem;
     }
   }
 }
 
 .secondaryRichTextHeading {
-  margin-bottom: calc(var(--base) * 1.5);
+  margin-bottom: 1.5rem;
 
   h2 {
     @include h3;
@@ -298,7 +298,7 @@
 
 .richTextDescription, .secondaryRichTextDescription {
   max-width: 50%;
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include mid-break {
     max-width: 100%;
@@ -319,7 +319,7 @@
 
 .primaryButtons {
   @include mid-break {
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 }
 
@@ -341,13 +341,13 @@
 
 .mobilePedestalBackgroundGrid {
   @include mid-break {
-    left: calc(calc(var(--base) * 10) + var(--gutter-h));
-    width: calc(calc(100% - var(--base) * 10) - var(--gutter-h) * 2)
+    left: calc(10rem + var(--gutter-h));
+    width: calc((100% - 10rem) - var(--gutter-h) * 2)
   }
 
   @include small-break {
-    left: calc(calc(var(--base) * 6) + var(--gutter-h));
-    width: calc(calc(100% - var(--base) * 8) - var(--gutter-h) * 2)
+    left: calc(6rem + var(--gutter-h));
+    width: calc((100% - 8rem) - var(--gutter-h) * 2)
   }
 }
 

--- a/src/components/Hero/Livestream/index.module.scss
+++ b/src/components/Hero/Livestream/index.module.scss
@@ -2,30 +2,30 @@
 
 .livestreamHero {
   position: relative;
-  margin-top: calc(var(--base) * -2);
+  margin-top: -2rem;
   color: var(--color-base-100);
 
   @include mid-break {
-    margin-top: calc(var(--base) * -1);
+    margin-top: -1rem;
   }
 }
 
 .gutter {
   position: relative;
-  padding-top: calc(var(--base) * 4);
-  padding-bottom: calc(var(--base) * 4);
+  padding-top: 4rem;
+  padding-bottom: 4rem;
 }
 
 .linkCell,
 .videoCell {
-  padding: calc(var(--base) * 2) 0;
+  padding: 2rem 0;
 
   &>*:not(:last-child) {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 
   @include mid-break {
-    margin-top: var(--base);
+    margin-top: 1rem;
     padding: 0;
   }
 }
@@ -52,7 +52,7 @@
 
 .link {
   &:not(:last-child) {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 
   &--secondary {
@@ -69,7 +69,7 @@
     }
 
     & svg {
-      margin-left: var(--base);
+      margin-left: 1rem;
     }
 
     @include mid-break {
@@ -84,8 +84,8 @@
   flex-direction: row;
   align-items: center;
   text-decoration: none;
-  margin-top: calc(var(--base) * 2.5);
-  margin-bottom: calc(var(--base) * 1.25);
+  margin-top: 2.5rem;
+  margin-bottom: 1.25rem;
   width: fit-content;
 
   & img {
@@ -93,13 +93,13 @@
     height: 45px;
     border-radius: 100%;
     overflow: hidden;
-    margin-right: calc(var(--base) * 1.5);
+    margin-right: 1.5rem;
     border: none;
     flex-shrink: 0;
   }
 
   &:last-child {
-    margin-top: var(--base);
+    margin-top: 1rem;
     margin-bottom: 0;
   }
 }
@@ -143,9 +143,9 @@
 
 .bg2Wrapper {
   width: 100%;
-  height: calc(100% - (var(--base) * 4));
-  top: calc(var(--base) * 2);
-  
+  height: calc(100% - 4rem);
+  top: 2rem;
+
   position: absolute;
   left: 0;
 }

--- a/src/components/Jumplist/index.module.scss
+++ b/src/components/Jumplist/index.module.scss
@@ -4,7 +4,7 @@
 
   letter-spacing: 0;
 
-  scroll-margin-top: calc(var(--header-height) + var(--base));
+  scroll-margin-top: calc(var(--header-height) + 1rem);
   position: relative;
 
   * {
@@ -13,7 +13,7 @@
 
   &:hover {
     .linkedHeading {
-      opacity: .75;
+      opacity: 0.75;
     }
   }
 }
@@ -22,12 +22,12 @@
   position: absolute;
   transform: translate(-50%, -50%);
   transition: opacity 200ms ease;
-  opacity: .25;
+  opacity: 0.25;
   top: 50%;
-  left: calc(var(--base) * -1.15);
+  left: -1.15rem;
 
   @include small-break {
     transform: translate(-50%, -50%) scale(.65);
-    left: calc(var(--base) * -.5);
+    left: -.5rem;
   }
 }

--- a/src/components/Label/index.module.scss
+++ b/src/components/Label/index.module.scss
@@ -10,5 +10,5 @@
 .label + h4,
 .label + h5,
 .label + h6 {
-  margin-top: var(--base);
+  margin-top: 1rem;
 }

--- a/src/components/LargeRadio/index.module.scss
+++ b/src/components/LargeRadio/index.module.scss
@@ -4,7 +4,7 @@
     display: flex;
     width: 100%;
     align-items: center;
-    padding: var(--base) var(--base);
+    padding: 1rem 1rem;
     border: 1px solid var(--theme-elevation-200);
     background-color: transparent;
     text-align: left;
@@ -18,7 +18,7 @@
     }
 
     @include mid-break {
-        padding: calc(var(--base) / 1.5);
+        padding: 0.67rem;
 
         &:hover {
             border-color: var(--theme-elevation-200);
@@ -28,7 +28,7 @@
 
 .disabled {
     color: var(--theme-elevation-300);
-    
+
     &:hover {
         border-color: var(--theme-elevation-200);
     }
@@ -52,15 +52,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: calc(var(--base) * 1.5);
-    height: calc(var(--base) * 1.5);
+    width: 1.5rem;
+    height: 1.5rem;
     border-radius: 100%;
     border: 1px solid var(--theme-elevation-200);
-    margin-right: var(--base);
+    margin-right: 1rem;
     flex-shrink: 0;
 
     @include mid-break {
-        margin-right: calc(var(--base) / 1.5);
+        margin-right: 0.67rem;
     }
 }
 
@@ -80,7 +80,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
-    gap: calc(var(--base) / 2);
+    gap: 0.5rem;
 
     @include small-break {
         display: flex;
@@ -119,7 +119,7 @@
 
     .checked {
         border-color: var(--theme-success-600);
-        
+
         &:local() {
             .checkmark {
                 border-color: var(--theme-success-700);

--- a/src/components/LineDraw/index.module.scss
+++ b/src/components/LineDraw/index.module.scss
@@ -1,6 +1,6 @@
 @use '@scss/common.scss' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .lineDraw {
   position: relative;
@@ -28,7 +28,7 @@ $curve: cubic-bezier(.165, .84, .44, 1);
     transform-origin: bottom right;
     transition: transform 500ms ease-out;
   }
-  
+
   &.isHovered {
     &::after {
       transform: scaleX(1);

--- a/src/components/LoadingShimmer/index.module.scss
+++ b/src/components/LoadingShimmer/index.module.scss
@@ -3,24 +3,24 @@
 @keyframes shimmer {
     0% {
         opacity: 1;
-    }   
+    }
     50% {
-        opacity: .75;
+        opacity: 0.75;
     }
     100% {
         opacity: 1;
     }
-}    
+}
 
 .loading {
     & > *:not(:last-child) {
-        margin-bottom: var(--base);
+        margin-bottom: 1rem;
     }
 }
 
 .shimmer {
     width: 100%;
-    height: calc(var(--base) * 2.5); // same as input height `formInput`
+    height: 2.5rem; // same as input height `formInput`
     background-color: var(--theme-elevation-50);
     border-radius: 1px;
     opacity: 1;

--- a/src/components/LoadingShimmer/index.tsx
+++ b/src/components/LoadingShimmer/index.tsx
@@ -14,7 +14,7 @@ export const LoadingShimmer: React.FC<{
 
   const arrayFromNumber = Array.from(Array(number || 1).keys())
 
-  let height = heightBase ? `calc(${heightBase} * var(--base))` : undefined
+  let height = heightBase ? `calc(${heightBase} * 1rem)` : undefined
   if (typeof heightPercent === 'number') {
     height = `${heightPercent}%`
   }
@@ -27,7 +27,7 @@ export const LoadingShimmer: React.FC<{
           className={[shimmerClassName, classes.shimmer].filter(Boolean).join(' ')}
           style={{
             height,
-            width: props.width ? `calc(${props.width} * var(--base))` : undefined,
+            width: props.width ? `calc(${props.width} * 1rem)` : undefined,
           }}
         />
       ))}

--- a/src/components/MDX/components/Banner/index.module.scss
+++ b/src/components/MDX/components/Banner/index.module.scss
@@ -1,7 +1,7 @@
 @use '@scss/common.scss' as *;
 
 .banner {
-  padding: calc(var(--base) * 2) var(--column);
+  padding: 2rem var(--column);
   margin: 0 calc(var(--column) * -1);
   display: flex;
 
@@ -64,7 +64,7 @@
 
 
   & > p {
-    line-height: calc(var(--base) * 1.25);
+    line-height: 1.25rem;
   }
 
   *:first-child {
@@ -80,9 +80,9 @@
   background-color: currentColor;
   border-radius: 50%;
   flex-shrink: 0;
-  margin: 5px var(--base) 0 0;
-  width: var(--base);
-  height: var(--base);
+  margin: 5px 1rem 0 0;
+  width: 1rem;
+  height: 1rem;
   padding: 4px;
 
   path {

--- a/src/components/MDX/components/BlogImage/index.module.scss
+++ b/src/components/MDX/components/BlogImage/index.module.scss
@@ -2,7 +2,7 @@
 
 .blogImage {
   max-width: unset !important;
-  margin: calc(var(--base) * 2.5) auto;
+  margin: 2.5rem auto;
 
   >div {
     vertical-align: middle;
@@ -15,19 +15,19 @@
   }
 
   @include large-break {
-    margin: calc(var(--base) * 2) auto;
+    margin: 2rem auto;
   }
 
   @include small-break {
-    margin: calc(var(--base) * 1.5) auto;
+    margin: 1.5rem auto;
   }
 }
 
 .caption {
   text-align: center;
   font-style: italic;
-  padding: calc(var(--base) * .75) 0 0;
-  max-width: calc(var(--base) * 25);
+  padding: 0.75rem 0 0;
+  max-width: 25rem;
   margin-left: auto;
   margin-right: auto;
 }
@@ -35,6 +35,6 @@
 
 .shadow {
   img {
-    box-shadow: 0 0 150px rgba(0, 0, 0, .125);
+    box-shadow: 0 0 150px rgba(0, 0, 0, 0.125);
   }
 }

--- a/src/components/MDX/components/Code/index.module.scss
+++ b/src/components/MDX/components/Code/index.module.scss
@@ -3,12 +3,12 @@
 .codeWrap {
   background: var(--color-base-900);
   margin: 0 calc(var(--column) * -1);
-  margin-bottom: calc(var(--base)*2);
+  margin-bottom: 2rem;
   padding: 0;
 
   @include mid-break {
     margin: 0;
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
   }
 }
 

--- a/src/components/MDX/components/CustomTable/index.module.scss
+++ b/src/components/MDX/components/CustomTable/index.module.scss
@@ -1,7 +1,7 @@
 @use "@scss/common" as *;
 
 .table {
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 
   & table {
     width: 100%;
@@ -16,11 +16,11 @@
   }
 
   th {
-    padding: var(--base);
+    padding: 1rem;
   }
 
   td {
-    padding: 0 var(--base);
+    padding: 0 1rem;
     min-width: 60px;
   }
 
@@ -55,7 +55,7 @@
   @include mid-break {
     th,
     td {
-      padding: calc(var(--base)*0.5);
+      padding: 0.5rem;
       min-width: 40px;
     }
   }

--- a/src/components/MDX/components/HR/index.module.scss
+++ b/src/components/MDX/components/HR/index.module.scss
@@ -1,5 +1,5 @@
 @use "@scss/common" as *;
 
 .hr {
-  margin: calc(var(--base) * 2) auto;
+  margin: 2rem auto;
 }

--- a/src/components/MDX/components/LightDarkImage/index.module.scss
+++ b/src/components/MDX/components/LightDarkImage/index.module.scss
@@ -1,18 +1,18 @@
 @use "@scss/common" as *;
 
 .imageWrap {
-  margin: calc(var(--base) * 2.5) 0;
+  margin: 2.5rem 0;
 
   .caption {
     font-style: italic;
-    padding: calc(var(--base) * .75) 0 0;
+    padding: 0.75rem 0 0;
   }
 
   @include large-break {
-    margin: calc(var(--base) * 2) 0;
+    margin: 2rem 0;
   }
 
   @include small-break {
-    margin: calc(var(--base) * 1.5) 0;
+    margin: 1.5rem 0;
   }
 }

--- a/src/components/MDX/components/RestExamples/index.module.scss
+++ b/src/components/MDX/components/RestExamples/index.module.scss
@@ -7,7 +7,7 @@
   margin-right: auto;
   background-color: var(--color-base-750);
   border-radius: 3px;
-  padding: calc(var(--base)*0.35);
+  padding: 0.35rem;
   transition: opacity 200ms linear;
   cursor: pointer;
   color: var(--color-base-100);
@@ -38,7 +38,7 @@
 }
 
 .drawerContent {
-  margin-top: var(--base);
+  margin-top: 1rem;
   z-index: 99;
 }
 
@@ -47,17 +47,17 @@
   -webkit-overflow-scrolling: touch;
   overflow-x: scroll;
   pointer-events: all;
-  padding-bottom: calc(var(--base)*2);
+  padding-bottom: 2rem;
 }
 
 @include large-break {
   .toggle {
-    padding: calc(var(--base)*0.25);
+    padding: 0.25rem;
   }
 
   .table {
     & td, & th {
-      padding: calc(var(--base)*0.5);
+      padding: 0.5rem;
     }
   }
 
@@ -72,7 +72,7 @@
 
 @include mid-break {
   .toggle {
-    padding: calc(var(--base)*0.15);
+    padding: 0.15rem;
   }
 
   .drawerTable, .table {
@@ -90,7 +90,7 @@
   }
 
   .code {
-    padding-bottom: calc(var(--base)*1.25);
+    padding-bottom: 1.25rem;
     font-size: 11px;
   }
 }

--- a/src/components/MDX/components/Table/index.module.scss
+++ b/src/components/MDX/components/Table/index.module.scss
@@ -6,7 +6,7 @@
 
   :global {
     table {
-      margin-bottom: var(--base);
+      margin-bottom: 1rem;
       overflow: auto;
       max-width: 100%;
       width: 100%;
@@ -23,7 +23,7 @@
       }
 
       th, td {
-        padding: calc(var(--base) * .75);
+        padding: 0.75rem;
         min-width: 150px;
         vertical-align: top;
         max-width: 1000px;
@@ -60,20 +60,20 @@
 
       @include mid-break {
         th, td {
-          padding: calc(var(--base) * .5);
+          padding: 0.5rem;
         }
       }
     }
   }
 
   @include mid-break {
-    margin: 0 calc(var(--base)*-2)!important;
+    margin: 0 -2rem !important;
     padding: 0!important;
   }
 
 
 @include small-break {
-  margin: 0 calc(var(--base)*-1)!important;
-  padding: 0 var(--base)!important;
+  margin: 0 -1rem !important;
+  padding: 0 1rem!important;
 }
 }

--- a/src/components/MDX/components/TableWithDrawers/index.module.scss
+++ b/src/components/MDX/components/TableWithDrawers/index.module.scss
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: .5;
+  opacity: 0.5;
   transition: opacity var(--duration) ease;
   outline: 1px solid;
   border-radius: 50%;
@@ -24,7 +24,7 @@
 
   :global {
     table {
-      margin-bottom: var(--base);
+      margin-bottom: 1rem;
       overflow: auto;
       max-width: 100%;
       width: 100%;
@@ -41,7 +41,7 @@
       }
 
       th, td {
-        padding: calc(var(--base) * .75);
+        padding: 0.75rem;
         min-width: 150px;
         vertical-align: top;
       }
@@ -57,7 +57,7 @@
       @include mid-break {
         th, td {
           max-width: 70vw;
-          padding: calc(var(--base) * .5);
+          padding: 0.5rem;
         }
       }
     }
@@ -66,8 +66,8 @@
   @include mid-break {
     margin-left: calc(var(--gutter-h) * -1);
     margin-right: calc(var(--gutter-h) * -1);
-    padding-left: calc(var(--gutter-h) * .5);
-    padding-right: calc(var(--gutter-h) * .5);
+    padding-left: calc(var(--gutter-h) * 0.5);
+    padding-right: calc(var(--gutter-h) * 0.5);
     width: calc(100% + (var(--gutter-h) * 2));
     max-width: calc(100% + (var(--gutter-h) * 2));
   }

--- a/src/components/MDX/components/VideoDrawer/index.module.scss
+++ b/src/components/MDX/components/VideoDrawer/index.module.scss
@@ -3,7 +3,7 @@
 .videoDrawerToggler {
   @include btnReset;
   width: 100%;
-  margin: calc(var(--base) * .5) 0 calc(var(--base) * 1.5) 0;
+  margin: 0.5rem 0 1.5rem 0;
   background: var(--theme-elevation-150);
   transition: all 200ms ease-in-out;
   border-bottom: 2px solid var(--theme-elevation-700);
@@ -25,7 +25,7 @@
     position: relative;
     flex-shrink: 0;
     height: auto;
-    width: calc(var(--base) * 6);
+    width: 6rem;
   }
 
   .playIcon {
@@ -37,12 +37,12 @@
   }
 
   .arrow {
-    margin-left: var(--base);
+    margin-left: 1rem;
   }
 
   .labelWrap {
     width: 100%;
-    padding: calc(var(--base)*1.5);
+    padding: 1.5rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -51,13 +51,13 @@
 
   @include large-break {
     .labelWrap {
-      padding: calc(var(--base) * 1);
+      padding: 1rem;
     }
   }
 
   @include mid-break {
     .thumbnail {
-      width: calc(var(--base) * 4);
+      width: 4rem;
     }
   }
 
@@ -66,10 +66,10 @@
       display: inline-block;
     }
 
-    .arrow { 
-      margin-left: calc(var(--base) * 0.5);
-      width: calc(var(--base) * 0.5);
-      height: calc(var(--base) * 0.5);
+    .arrow {
+      margin-left: 0.5rem;
+      width: 0.5rem;
+      height: 0.5rem;
     }
   }
 }

--- a/src/components/ModalWindow/index.module.scss
+++ b/src/components/ModalWindow/index.module.scss
@@ -12,7 +12,7 @@
 .window {
   background-color: var(--theme-bg);
   border: 1px solid var(--theme-elevation-250);
-  padding: calc(var(--base) * 2);
+  padding: 2rem;
   width: 700px;
   max-width: calc(100% - var(--gutter-h));
   margin: auto;

--- a/src/components/OpenPost/index.module.scss
+++ b/src/components/OpenPost/index.module.scss
@@ -5,13 +5,13 @@
   color: var(--theme-text-color);
   display: block;
   text-decoration: none;
-  padding: calc(var(--base) * 4) calc(var(--base) * 4);
+  padding: 4rem 4rem;
   border-top: 1px solid var(--theme-border-color);
   border-bottom: 1px solid var(--theme-border-color);
   background-color: var(--theme-elevation-0);
   margin-left: 1px;
   width: calc(100% - 2px);
-  transition: background-color .3s cubic-bezier(.165, .84, .44, 1);
+  transition: background-color 0.3s cubic-bezier(.165, 0.84, 0.44, 1);
 
   &::before {
     content: '';
@@ -24,7 +24,7 @@
   }
 
   h3 {
-    margin: calc(var(--base)*0.25) 0 0 0;
+    margin: 0.25rem 0 0 0;
   }
 
   .crosshairs {
@@ -32,7 +32,7 @@
   }
 
   @include mid-break {
-    padding: calc(var(--base) * 2);
+    padding: 2rem;
   }
 
   &:hover {
@@ -58,10 +58,10 @@
 
   svg {
     opacity: 0;
-    margin-left: calc(var(--base) * .5);
+    margin-left: 0.5rem;
     transform: translate(-5px, 5px);
     transition-property: opacity, transform;
     transition-duration: 0.3s;
-    transition-timing-function: cubic-bezier(.165, .84, .44, 1);
+    transition-timing-function: cubic-bezier(.165, 0.84, 0.44, 1);
   }
 }

--- a/src/components/Pagination/index.module.scss
+++ b/src/components/Pagination/index.module.scss
@@ -6,24 +6,24 @@
 }
 
 .page {
-  margin: 0 var(--base);
+  margin: 0 1rem;
 }
 
 .button {
   all: unset;
   cursor: pointer;
-  width: calc(var(--base) * 3);
-  height: calc(var(--base) * 3);
+  width: 3rem;
+  height: 3rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 1px solid;
   border-color: transparent;
-  margin-right: calc(var(--base) * 0.5);
+  margin-right: 0.5rem;
 
   svg {
-    width: var(--base);
-    height: var(--base);
+    width: 1rem;
+    height: 1rem;
   }
 
   &:hover {
@@ -41,23 +41,23 @@
   }
 
   @include small-break {
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
-    margin-right: calc(var(--base) * 0.25);
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0.25rem;
   }
 }
 
 .paginationButton {
   all: unset;
   cursor: pointer;
-  width: calc(var(--base) * 4);
-  height: calc(var(--base) * 4);
+  width: 4rem;
+  height: 4rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: 1px solid;
   border-color: transparent;
-  margin-right: calc(var(--base) * 0.5);
+  margin-right: 0.5rem;
   position: relative;
 
   &:hover {
@@ -73,9 +73,9 @@
   }
 
   @include small-break {
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
-    margin-right: calc(var(--base) * 0.25);
+    width: 2rem;
+    height: 2rem;
+    margin-right: 0.25rem;
   }
 }
 
@@ -108,7 +108,7 @@
 }
 
 .dash {
-  margin-right: calc(var(--base) * 0.5);
+  margin-right: 0.5rem;
 }
 
 .disabled {

--- a/src/components/Payload3D/index.module.scss
+++ b/src/components/Payload3D/index.module.scss
@@ -1,21 +1,21 @@
 @use '@scss/common' as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .container {
   position: relative;
-  padding-top: calc(var(--base) * 4);
-  margin-bottom: calc(var(--base) * -14.5);
+  padding-top: 4rem;
+  margin-bottom: -14.5rem;
 
   @include mid-break {
-    padding-top: calc(var(--base) * 4);
-    margin-bottom: calc(var(--base) * -12);
+    padding-top: 4rem;
+    margin-bottom: -12rem;
   }
 
   @include small-break {
     pointer-events: none;
-    padding-top: calc(var(--base) * 4);
-    margin-bottom: calc(var(--base) * -10);
+    padding-top: 4rem;
+    margin-bottom: -10rem;
   }
 }
 
@@ -34,11 +34,11 @@ $curve: cubic-bezier(.165, .84, .44, 1);
 }
 
 .gradient {
-  transform: translate3d(calc(var(--mouse-x, -100%)* 1px - var(--base)* 35), calc(var(--mouse-y, -100%)* 1px - var(--base)* 35), 0px);
+  transform: translate3d(calc(var(--mouse-x, -100%)* 1px - 35rem), calc(var(--mouse-y, -100%)* 1px - 35rem), 0px);
   position: absolute;
   filter: blur(100px);
-  width: calc(var(--base)* 70);
-  height: calc(var(--base)* 70);
+  width: 70rem;
+  height: 70rem;
   aspect-ratio: 1 / 1;
   border-radius: 100%;
   transition: opacity 1s $curve;
@@ -46,9 +46,9 @@ $curve: cubic-bezier(.165, .84, .44, 1);
   background: radial-gradient(circle at center, rgba(255,255,255,0.20), rgba(255,255,255,0.10), rgba(255,255,255,0));
 
   @include mid-break {
-    transform: translate3d(calc(var(--mouse-x, -100%)* 1px - var(--base)* 17.5), calc(var(--mouse-y, -100%)* 1px - var(--base)* 17.5), 0px);
-    width: calc(var(--base)* 35);
-    height: calc(var(--base)* 35);
+    transform: translate3d(calc(var(--mouse-x, -100%)* 1px - 17.5rem), calc(var(--mouse-y, -100%)* 1px - 17.5rem), 0px);
+    width: 35rem;
+    height: 35rem;
   }
 }
 

--- a/src/components/Pill/index.module.scss
+++ b/src/components/Pill/index.module.scss
@@ -5,7 +5,7 @@
   align-items: center;
   color: var(--color-success-500);
   border-radius: 19px;
-  padding: 4px calc(var(--base) * 0.5);
+  padding: 4px 0.5rem;
 }
 
 .color--default {
@@ -52,7 +52,7 @@
 
 @include small-break {
   .pill {
-    padding: calc(var(--base) * 0.25) calc(var(--base) * 0.45);
+    padding: 0.25rem 0.45rem;
     margin: 0;
     max-height: 28px;
   }

--- a/src/components/PrivacyBanner/index.module.scss
+++ b/src/components/PrivacyBanner/index.module.scss
@@ -2,7 +2,7 @@
 
 .privacyBanner {
   position: fixed;
-  bottom: var(--base);
+  bottom: 1rem;
   right: var(--gutter-h);
   width: max-content;
   z-index: var(--z-nav);
@@ -34,7 +34,7 @@
   align-items: center;
   position: relative;
   background: black;
-  padding: calc(var(--base) * 1.5);
+  padding: 1.5rem;
 
   @include large-break {
     margin-left: 0;
@@ -77,8 +77,8 @@
 
 .buttonWrap {
   display: flex;
-  margin-top: calc(var(--base) * 1.5);
-  gap: var(--base);
+  margin-top: 1.5rem;
+  gap: 1rem;
   width: 100%;
 
   button {
@@ -86,7 +86,7 @@
   }
 
   @include small-break {
-    margin-top: var(--base);
+    margin-top: 1rem;
   }
 }
 

--- a/src/components/RelatedHelpList/index.module.scss
+++ b/src/components/RelatedHelpList/index.module.scss
@@ -2,11 +2,11 @@
 
 .relatedHelpList {
   position: relative;
-  padding: calc(var(--base) * 2) 0;
+  padding: 2rem 0;
 
   .titleWrapper {
-    padding-top: calc(var(--base) * 1.5);
-    margin-bottom: var(--base);
+    padding-top: 1.5rem;
+    margin-bottom: 1rem;
   }
 
   .title {
@@ -15,16 +15,16 @@
 
   ul {
     display: flex;
-    gap: calc(var(--base) * 0.25);
+    gap: 0.25rem;
     flex-direction: column;
     list-style: none;
     padding-left: 0;
-    margin-bottom: calc(var(--base) * 1.5);
+    margin-bottom: 1.5rem;
   }
 
   li {
     position: relative;
-    padding-left: calc(var(--base) * 1.5);
+    padding-left: 1.5rem;
   }
 
   .itemMarker {

--- a/src/components/RichText/Video/index.module.scss
+++ b/src/components/RichText/Video/index.module.scss
@@ -6,7 +6,7 @@
   width: 100%;
   background-color: var(--theme-elevation-0);
   overflow: hidden;
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 }
 
 .iframe {

--- a/src/components/SpotlightAnimation/index.module.scss
+++ b/src/components/SpotlightAnimation/index.module.scss
@@ -1,6 +1,6 @@
 @use "@scss/common" as *;
 
-$curve: cubic-bezier(.165, .84, .44, 1);
+$curve: cubic-bezier(.165, 0.84, 0.44, 1);
 
 .wrapper {
   position: relative;

--- a/src/components/TableOfContents/index.module.scss
+++ b/src/components/TableOfContents/index.module.scss
@@ -2,14 +2,14 @@
 
 .wrap {
   position: relative;
-  padding: 0 var(--base);
-  font-size: calc(var(--base) * .85);
+  padding: 0 1rem;
+  font-size: 0.85rem;
 }
 
 .toc {
   list-style: none;
   padding: 0;
-  margin: 0 0 calc(var(--base) * 2);
+  margin: 0 0 2rem;
 
   a {
     text-decoration: none;
@@ -19,21 +19,21 @@
 
 .tocTitle {
   font-weight: 400;
-  font-size: calc(var(--base) * .55);
+  font-size: 0.55rem;
   letter-spacing: 2.75px;
   text-transform: uppercase;
-  margin: 0 0 var(--base) 0;
+  margin: 0 0 1rem 0;
 }
 
 .heading {
   transition: all 400ms;
   position: relative;
   line-height: 1.375;
-  margin-bottom: calc(var(--base) * .75);
-  margin-right: var(--base);
+  margin-bottom: 0.75rem;
+  margin-right: 1rem;
 
   &:hover {
-    transform: translate3d(calc(var(--base) * .25), 0, 0);
+    transform: translate3d(.25rem, 0, 0);
   }
 }
 
@@ -51,7 +51,7 @@
   left: 0;
   top: 0;
   transition: all var(--trans-default) ease-in-out;
-  height: calc(var(--base) * 1.3);
+  height: 1.3rem;
   background-color: var(--theme-elevation-800);
   width: 2px;
 }

--- a/src/components/Tooltip/TooltipContent/index.module.scss
+++ b/src/components/Tooltip/TooltipContent/index.module.scss
@@ -7,9 +7,9 @@
   left: 50%;
   z-index: 2;
   transform: translate3d(-50%, -50%, 0);
-  padding: calc(var(--base) * .5) calc(var(--base) * .75);
+  padding: 0.5rem 0.75rem;
   color: var(--theme-text);
-  line-height: calc(var(--base) * .75);
+  line-height: 0.75rem;
   font-weight: normal;
   white-space: nowrap;
   background-color: var(--theme-elevation-100);
@@ -22,7 +22,7 @@
 .caret {
   position: absolute;
   transform: translateX(-50%);
-  top: calc(100% - calc(var(--base) * .0625));
+  top: calc(100% - 0.0625rem);
   left: 50%;
   height: 0;
   width: 0;

--- a/src/components/Tooltip/index.module.scss
+++ b/src/components/Tooltip/index.module.scss
@@ -18,7 +18,7 @@
 
   .tip {
     opacity: 0;
-    transition: opacity .15s cubic-bezier(.165, .84, .44, 1);
+    transition: opacity 0.15s cubic-bezier(.165, 0.84, 0.44, 1);
     pointer-events: none;
   }
 

--- a/src/components/TopBar/index.module.scss
+++ b/src/components/TopBar/index.module.scss
@@ -1,6 +1,6 @@
 @use '@scss/common' as *;
 
-.topBar {  
+.topBar {
   position: fixed;
   top: 0;
   height: var(--top-bar-height);
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: var(--base);
+    gap: 1rem;
     width: 100%;
     height: 100%;
     pointer-events: all;
@@ -33,7 +33,7 @@
   .starWrap {
     display: flex;
     flex-direction: row;
-    gap: calc(var(--base) * 0.25);
+    gap: 0.25rem;
   }
 
   .starCount {
@@ -65,18 +65,18 @@
       font-size: 14px;
     }
   }
-  
+
   @include mid-break {
     .richText {
       display: none;
     }
-  
+
     .mobileText {
       display: unset;
 
       & a {
         color: var(--text-color);
-  
+
         &:visited {
           color: var(--text-color);
         }

--- a/src/components/YouTube/index.module.scss
+++ b/src/components/YouTube/index.module.scss
@@ -1,8 +1,8 @@
 @use "@scss/common" as *;
 
 .wrap {
-  margin-top: calc(var(--base) * 2);
-  margin-bottom: calc(var(--base) * 2);
+  margin-top: 2rem;
+  margin-bottom: 2rem;
   box-shadow: 0 0 150px rgb(0 0 0 / 13%);
 }
 

--- a/src/components/cards/ContentMediaCard/index.module.scss
+++ b/src/components/cards/ContentMediaCard/index.module.scss
@@ -31,7 +31,7 @@
   @include small-break {
     width: 100%;
     padding: 0;
-    margin-bottom: calc(var(--base) * 2);
+    margin-bottom: 2rem;
     max-width: 100%;
   }
 }
@@ -39,12 +39,12 @@
 .meta {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) * 1);
+  gap: 1rem;
   opacity: 0.5;
-  margin-bottom: calc(var(--base) * 1.2);
+  margin-bottom: 1.2rem;
 
   @include small-break {
-    margin-bottom: calc(var(--base) * 0.6);
+    margin-bottom: 0.6rem;
   }
 
   time {
@@ -66,11 +66,11 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
   width: 50%;
   text-decoration: none;
-  padding-left: calc(var(--base) * 2);
-  padding-right: calc(var(--base) * 2);
+  padding-left: 2rem;
+  padding-right: 2rem;
 
   @include small-break {
     width: 100%;

--- a/src/components/cards/DefaultCard/index.module.scss
+++ b/src/components/cards/DefaultCard/index.module.scss
@@ -46,35 +46,35 @@
 }
 
 .content {
-  padding: calc(var(--base) * 2);
+  padding: 2rem;
   padding-bottom: 0;
 
   @include mid-break {
-    padding: var(--base);
+    padding: 1rem;
     padding-bottom: 0;
   }
 }
 
 .description {
-  margin-bottom: calc(var(--base) * 2);
+  margin-bottom: 2rem;
 
   @include mid-break {
-    margin-bottom: var(--base);
+    margin-bottom: 1rem;
   }
 }
 
 .media {
-  padding-left: calc(var(--base) * 2);
+  padding-left: 2rem;
 
   @include mid-break {
-    padding-left: var(--base);
+    padding-left: 1rem;
   }
 }
 
 .leaderWrapper {
   display: flex;
   align-items: center;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .leader {
@@ -82,29 +82,29 @@
   @include label;
 
   @include mid-break {
-    margin-bottom: calc(var(--base) / 2);
+    margin-bottom: 0.5rem;
   }
 }
 
 .pill {
   @include mid-break {
-    margin-bottom: calc(var(--base) / 2);
+    margin-bottom: 0.5rem;
   }
 }
 
 .plusIcon {
   position: absolute;
-  top: var(--base);
-  right: var(--base);
-  width: calc(var(--base) * 2.5);
-  height: calc(var(--base) * 2.5);
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
   color: var(--theme-elevation-200);
   transition: 25ms linear color;
 
   @include mid-break {
-    top: calc(var(--base) * 0.5);
-    right: calc(var(--base) * 0.5);
-    width: calc(var(--base) * 2);
-    height: calc(var(--base) * 2);
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 2rem;
+    height: 2rem;
   }
 }

--- a/src/components/cards/PricingCard/index.module.scss
+++ b/src/components/cards/PricingCard/index.module.scss
@@ -4,10 +4,10 @@
   position: relative;
   border-top: 1px solid var(--grid-line-dark);
   border-bottom: 1px solid var(--grid-line-dark);
-  padding: calc(var(--base) * 3) calc(var(--base) * 1.5);
+  padding: 3rem 1.5rem;
 
   @include mid-break {
-    padding: calc(var(--base) * 2) calc(var(--base) * 1);
+    padding: 2rem 1rem;
   }
 
   & path {
@@ -34,7 +34,7 @@
   text-transform: uppercase;
   color: #51BFF6;
   margin-top: 0;
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
   display: block;
 }
 
@@ -47,7 +47,7 @@
   @include h2;
   position: relative;
   margin: 0;
-  margin-bottom: var(--base);
+  margin-bottom: 1rem;
 
 }
 
@@ -60,9 +60,9 @@
 .arrow {
     position: absolute;
     opacity: 1;
-    margin: calc(var(--base) * 2);
+    margin: 2rem;
     top: 0;
     right: 0;
-    width: var(--base);
-    height: var(--base);
+    width: 1rem;
+    height: 1rem;
 }

--- a/src/components/cards/SquareCard/index.module.scss
+++ b/src/components/cards/SquareCard/index.module.scss
@@ -3,12 +3,12 @@
 .card {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--base) * 1.5);
-  padding: calc(var(--base) * 1.5);
+  gap: 1.5rem;
+  padding: 1.5rem;
   text-decoration: none;
   aspect-ratio: 1 / 1;
   transition: background-color, gap, padding-bottom;
-  transition-duration: .4s;
+  transition-duration: 0.4s;
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
   border-bottom: 1px solid var(--grid-line-light);
 
@@ -27,12 +27,12 @@
 
   .scanlines {
     opacity: 0;
-    transition: opacity .4s cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition: opacity 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
   }
 
   &.link:hover {
-    padding-bottom: calc(var(--base) * 3);
-    gap: var(--base);
+    padding-bottom: 3rem;
+    gap: 1rem;
 
     .title {
       margin-bottom: 0;
@@ -69,7 +69,7 @@
       opacity: 1;
 
       .description {
-        padding-bottom: calc(var(--base) * 1.5);
+        padding-bottom: 1.5rem;
       }
     }
   }
@@ -80,7 +80,7 @@
   }
 
   .titleWrapper {
-    padding-bottom: calc(var(--base) * 1.5);
+    padding-bottom: 1.5rem;
   }
 
 }
@@ -98,7 +98,7 @@
   .icon {
     transform: translateY(10px);
     opacity: 0;
-    transition: transform .4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity .4s cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition: transform 0.4s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.4s cubic-bezier(0.165, 0.84, 0.44, 1);
   }
 }
 
@@ -110,24 +110,24 @@
 }
 
 .title {
-  font-size: calc(var(--base) * 1.5);
+  font-size: 1.5rem;
   line-height: 1.2em;
   margin: 0;
 
   @include large-mid-break {
-    font-size: calc(var(--base) * 1.4);
+    font-size: 1.4rem;
   }
 
   @include mid-break {
-    font-size: calc(var(--base) * 1.5);
+    font-size: 1.5rem;
   }
 
   @include small-break {
-    font-size: calc(var(--base) * 1.25);
+    font-size: 1.25rem;
   }
 
   &.noDescription {
-    margin-bottom: calc(var(--base) * .5);
+    margin-bottom: 0.5rem;
   }
 }
 
@@ -151,7 +151,7 @@
   grid-template-rows: 0fr;
   opacity: 0;
   transition-property: grid-template-rows, opacity;
-  transition-duration: .4s;
+  transition-duration: 0.4s;
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
 
   .description {
@@ -162,7 +162,7 @@
     margin: 0;
     height: auto;
     transition-property: padding;
-    transition-duration: .4s;
+    transition-duration: 0.4s;
     transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
   }
 }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -9,6 +9,7 @@
 @import "./theme.scss";
 
 :root {
+  font-size: 20px;
   --base: 20px;
   --breakpoint-xs-width: $breakpoint-xs-width;
   --breakpoint-s-width: $breakpoint-s-width;
@@ -39,23 +40,24 @@
   --text-dark: rgba(255, 255, 255, 0.5);
   --text-light: rgba(0, 0, 0, 0.5);
 
-  --gutter-h: calc(50vw - (var(--base) * 40));
-  --block-spacing: calc(var(--base) * 7);
-  --new-block-spacing: calc(var(--base) * 8);
+  --gutter-h: calc(50vw - 40rem);
+  --block-spacing: 7rem;
+  --new-block-spacing: 8rem;
   --default-border-width: 2px;
 
   --trans-default: 150ms;
 
   @include extra-large-break {
     --font-body-size: 16px;
-    --gutter-h: calc(var(--base) * 8);
+    --gutter-h: 8rem;
   }
 
   @include large-break {
+    font-size: 16px;
     --base: 16px;
-    --gutter-h: calc(var(--base) * 4);
-    --block-spacing: calc(var(--base) * 5);
-    --new-block-spacing: calc(var(--base) * 6);
+    --gutter-h: 4rem;
+    --block-spacing: 5rem;
+    --new-block-spacing: 6rem;
     --header-height: 76px;
   }
 
@@ -64,15 +66,15 @@
   }
 
   @include mid-break {
-    --gutter-h: calc(var(--base) * 2);
-    --block-spacing: calc(var(--base) * 3.5);
-    --new-block-spacing: calc(var(--base) * 4);
+    --gutter-h: 2rem;
+    --block-spacing: 3.5rem;
+    --new-block-spacing: 4rem;
     --page-padding-top: var(--header-height);
   }
 
   @include small-break {
-    --block-spacing: calc(var(--base) * 2);
-    --gutter-h: calc(var(--base) * 1);
+    --block-spacing: 2rem;
+    --gutter-h: 1rem;
   }
 
   --column: calc((100vw - (var(--gutter-h) * 2)) / 16);
@@ -159,11 +161,11 @@ h6 {
 }
 
 p {
-  margin: calc(var(--base) * 1.8) 0 calc(var(--base) * 1.8);
+  margin: 1.8rem 0 1.8rem;
 
   & + p {
     // If a paragraph follows another paragraph, reduce the margin
-    margin: calc(var(--base) * 0.6 * -1) 0 calc(var(--base) * 1.8);
+    margin: -0.6rem 0 1.8rem;
   }
 }
 
@@ -173,8 +175,8 @@ small {
 
 ul,
 ol {
-  padding-left: calc(var(--base) * 2);
-  margin: 0 0 var(--base);
+  padding-left: 2rem;
+  margin: 0 0 1rem;
 }
 
 a {
@@ -183,7 +185,7 @@ a {
   text-underline-offset: 2px;
 
   &:focus {
-    opacity: .8;
+    opacity: 0.8;
     outline: none;
     text-decoration: underline;
   }
@@ -193,7 +195,7 @@ a {
   }
 
   &:active {
-    opacity: .7;
+    opacity: 0.7;
     outline: none;
   }
 

--- a/src/css/docsearch.scss
+++ b/src/css/docsearch.scss
@@ -10,7 +10,7 @@
 
     &:hover {
       .DocSearch-Search-Icon {
-        opacity: .8;
+        opacity: 0.8;
       }
     }
 
@@ -37,7 +37,7 @@
     width: 100vw;
     cursor: auto;
     flex-direction: column;
-    padding: var(--base);
+    padding: 1rem;
     padding-bottom: 0;
     max-height: 100vh;
     overflow-y: scroll;
@@ -93,7 +93,7 @@
         position: absolute;
         transform: translateY(-50%);
         top: 50%;
-        left: var(--base);
+        left: 1rem;
         color: var(--search-icon-color);
         svg {
           height: 15px;
@@ -105,7 +105,7 @@
     .DocSearch-LoadingIndicator {
       display: none;
       position: absolute;
-      left: var(--base);
+      left: 1rem;
       width: 20px;
       height: 20px;
       top: 50%;
@@ -125,8 +125,8 @@
     }
 
     .DocSearch-Input {
-      --input-pad-left: calc(var(--base) * 2.5);
-      --input-pad-right: calc(var(--base) * 3.25);
+      --input-pad-left: 2.5rem;
+      --input-pad-right: 3.25rem;
       all: unset;
       width: calc(100% - var(--input-pad-left) - var(--input-pad-right));
       padding: 0;
@@ -142,7 +142,7 @@
     .DocSearch-Cancel {
       all: unset;
       position: absolute;
-      right: var(--base);
+      right: 1rem;
       top: 50%;
       transform: translateY(-50%);
       color: transparent;
@@ -154,7 +154,7 @@
         right: 0;
         width: 100%;
         height: 100%;
-        opacity: .85;
+        opacity: 0.85;
         top: 0;
         color: var(--color-base-0);
         font-size: 13px;
@@ -240,13 +240,13 @@
         bottom: 0;
         transform: translate(-50%, 50%);
         font-size: 20px;
-        opacity: .5;
+        opacity: 0.5;
       }
     }
 
     .DocSearch-Hit-source {
       position: relative;
-      padding: 0 0 0 var(--base);
+      padding: 0 0 0 1rem;
       margin: 0;
       line-height: 4;
       color: var(--color-base-0);
@@ -262,7 +262,7 @@
         bottom: 0;
         transform: translate(-50%, 50%);
         font-size: 20px;
-        opacity: .5;
+        opacity: 0.5;
       }
     }
   }
@@ -271,13 +271,13 @@
   // modal footer
   //----------------------
   .DocSearch-Footer {
-    padding: calc(var(--base) * .5) var(--base);
+    padding: 0.5rem 1rem;
     background: none;
 
     .DocSearch-Label {
-      margin-right: calc(var(--base) * .5);
+      margin-right: 0.5rem;
       @include small;
-      opacity: .75;
+      opacity: 0.75;
       text-decoration: none;
     }
 

--- a/src/css/github.scss
+++ b/src/css/github.scss
@@ -2,7 +2,7 @@ html {
   .Box-header {
     line-height: 1.2;
     background-color: var(--color-base-950);
-    padding: var(--base);
+    padding: 1rem;
     font-size: calc(var(--font-body-size) * 0.825);
     border: 1px solid var(--theme-elevation-50);
   }
@@ -11,11 +11,11 @@ html {
     line-height: 1.25;
     max-height: 250px;
     overflow: auto;
-    padding: var(--base);
+    padding: 1rem;
     background-color: var(--color-base-950);
     border: 1px solid var(--theme-elevation-50);
     font-family: var(--font-mono);
-    font-size: calc(var(--font-body-size) * .825);
+    font-size: calc(var(--font-body-size) * 0.825);
   }
 
   .blob-num::before {

--- a/src/css/toastify.scss
+++ b/src/css/toastify.scss
@@ -3,21 +3,21 @@
 
 .Toastify {
   .Toastify__toast-container {
-    left: calc(var(--base) * 5);
+    left: 5rem;
     transform: none;
-    right: calc(var(--base) * 5);
+    right: 5rem;
     width: auto;
   }
 
   .Toastify__toast {
-    padding: calc(var(--base) * .5) var(--base);
+    padding: 0.5rem 1rem;
     border-radius: 3px;
     font-weight: normal;
   }
 
   .Toastify__close-button {
     align-self: center;
-    opacity: .7;
+    opacity: 0.7;
 
     &:hover {
       opacity: 1;
@@ -52,8 +52,8 @@
 
   @include mid-break {
     .Toastify__toast-container {
-      left: var(--base);
-      right: var(--base);
+      left: 1rem;
+      right: 1rem;
     }
   }
 }

--- a/src/css/type.scss
+++ b/src/css/type.scss
@@ -30,79 +30,79 @@
 }
 
 @mixin h1 {
-  margin: calc(var(--base) * 3) 0 calc(var(--base) * 2.4);
-  font-size: calc(var(--base) * 4);
+  margin: 3rem 0 2.4rem;
+  font-size: 4rem;
   line-height: 1;
   font-weight: 500;
   letter-spacing: -0.05em;
 
   @include small-break {
-    font-size: calc(var(--base) * 2.5);
+    font-size: 2.5rem;
   }
 }
 
 @mixin h2 {
-  margin: calc(var(--base) * 2.4) 0 calc(var(--base) * 1.8);
-  font-size: calc(var(--base) * 3);
+  margin: 2.4rem 0 1.8rem;
+  font-size: 3rem;
   line-height: 1;
   font-weight: 500;
   letter-spacing: -0.05em;
 
   @include small-break {
-    font-size: calc(var(--base) * 1.75);
+    font-size: 1.75rem;
   }
 }
 
 @mixin h3 {
-  margin: calc(var(--base) * 1.8) 0 calc(var(--base) * 1.2);
-  font-size: calc(var(--base) * 2);
+  margin: 1.8rem 0 1.2rem;
+  font-size: 2rem;
   line-height: 1;
   font-weight: 500;
   letter-spacing: -0.05em;
 
   @include small-break {
-    font-size: calc(var(--base) * 1.5);
+    font-size: 1.5rem;
   }
 }
 
 @mixin h4 {
-  margin: calc(var(--base) * 1.2) 0;
-  font-size: calc(var(--base) * 1.4);
+  margin: 1.2rem 0;
+  font-size: 1.4rem;
   line-height: 1.2;
   font-weight: 500;
   letter-spacing: -0.05em;
 
   @include large-break {
-    font-size: calc(var(--base) * 1.5);
+    font-size: 1.5rem;
   }
 
   @include small-break {
-    font-size: calc(var(--base) * 1.125);
+    font-size: 1.125rem;
   }
 }
 
 @mixin h5 {
-  margin: calc(var(--base) * 1.2) 0;
-  font-size: calc(var(--base) * 1);
+  margin: 1.2rem 0;
+  font-size: 1rem;
   line-height: 1.2;
   font-weight: 500;
   letter-spacing: -0.05rem;
 
   @include large-break {
-    font-size: calc(var(--base) * 1.25);
+    font-size: 1.25rem;
   }
 
   @include small-break {
-    font-size: var(--base);
+    font-size: 1rem;
   }
 }
 
 @mixin h6 {
-  margin: calc(var(--base) * 1.2) 0;
+  margin: 1.2rem 0;
   font-size: 13px;
   line-height: 1;
   font-weight: 400;
-  letter-spacing: .25em;
+  letter-spacing: 0.25em;
 
   @include large-break {
     font-size: 12px;
@@ -141,33 +141,33 @@
 
 @mixin code {
   font-family: var(--font-mono);
-  font-size: calc(var(--font-body-size) * .825);
+  font-size: calc(var(--font-body-size) * 0.825);
 }
 
 @mixin label {
-  margin: calc(var(--base) * 1.2) 0;
-  font-size: calc(var(--base) * 1);
+  margin: 1.2rem 0;
+  font-size: 1rem;
   line-height: 1.2;
   font-weight: 400;
   letter-spacing: -0.05em;
 
   @include mid-break {
-    font-size: calc(var(--base) * 1);
+    font-size: 1rem;
   }
 
   @include small-break {
-    font-size: calc(var(--base) * 1);
+    font-size: 1rem;
   }
 }
 
 
 @mixin uppercaseLabel {
   color: var(--theme-elevation-900);
-  font-size: calc(var(--base) * 0.55);
+  font-size: 0.55rem;
   font-style: normal;
   font-weight: 400;
   line-height: 100%;
   letter-spacing: 2.75px;
   text-transform: uppercase;
-  margin: 0 0 calc(var(--base) * 0.75) 0;
+  margin: 0 0 0.75rem 0;
 }

--- a/src/css/vars.scss
+++ b/src/css/vars.scss
@@ -41,10 +41,10 @@ $breakpoint-l-height: 1000px;
 }
 
 @mixin shadow {
-  box-shadow: 0 12px 45px rgba(0, 0, 0, .03);
+  box-shadow: 0 12px 45px rgba(0, 0, 0, 0.03);
 
   &:hover {
-    box-shadow: 0 12px 45px rgba(0, 0, 0, .07);
+    box-shadow: 0 12px 45px rgba(0, 0, 0, 0.07);
   }
 }
 
@@ -88,7 +88,7 @@ $breakpoint-l-height: 1000px;
 
   &:before {
     background: $color;
-    opacity: .85;
+    opacity: 0.85;
   }
 
   &:after {
@@ -105,9 +105,9 @@ $breakpoint-l-height: 1000px;
   color: var(--theme-elevation-800);
   border-radius: 0;
   font-size: 1rem;
-  height: calc(var(--base) * 2);
-  line-height: var(--base);
-  padding: calc(var(--base) * 0.5) calc(var(--base) * 0.75);
+  height: 2rem;
+  line-height: 1rem;
+  padding: 0.5rem 0.75rem;
   -webkit-appearance: none;
 
   &::-webkit-input-placeholder {

--- a/src/forms/Label/index.module.scss
+++ b/src/forms/Label/index.module.scss
@@ -2,7 +2,7 @@
 
 .label {
   display: block;
-  margin-bottom: calc(var(--base) * 0.5);
+  margin-bottom: 0.5rem;
   color: var(--theme-elevation-650);
   line-height: 1;
   font-size: 14px;
@@ -13,14 +13,14 @@
 
 .required {
   color: var(--color-error-500);
-  margin: 0 calc(var(--base) * 0.25);
+  margin: 0 0.25rem;
 }
 
 .labelWithActions {
   width: 100%;
   display: flex;
   align-items: center;
-  margin-bottom: calc(var(--base) * 0.5);
+  margin-bottom: 0.5rem;
   display: inline-flex;
   width: 100%;
 
@@ -33,7 +33,7 @@
   display: flex;
   margin-left: auto;
   align-items: center;
-  gap: calc(var(--base) * .5);
+  gap: 0.5rem;
 }
 
 .noMargin {

--- a/src/forms/fields/Array/index.module.scss
+++ b/src/forms/fields/Array/index.module.scss
@@ -2,7 +2,7 @@
 
 .row {
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
   align-items: center;
 }
 

--- a/src/forms/fields/Checkbox/index.module.scss
+++ b/src/forms/fields/Checkbox/index.module.scss
@@ -54,9 +54,9 @@
   padding: 0;
   line-height: 0;
   position: relative;
-  width: calc(var(--base) * 1.25);
-  height: calc(var(--base) * 1.25);
-  margin-right: calc(var(--base) / 2);
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: 0.5rem;
   margin-bottom: 0;
   display: flex;
   align-items: center;

--- a/src/forms/fields/RadioGroup/index.module.scss
+++ b/src/forms/fields/RadioGroup/index.module.scss
@@ -10,7 +10,7 @@
   margin: 0;
   list-style: none;
   display: flex;
-  gap: var(--base);
+  gap: 1rem;
 }
 
 .layout--vertical {
@@ -20,7 +20,7 @@
     }
 
     .li {
-      gap: var(--base);
+      gap: 1rem;
     }
   }
 }
@@ -35,7 +35,7 @@
   cursor: pointer;
   flex-grow: 1;
   width: 100%;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 
   :global {
     input[type=radio] {
@@ -46,8 +46,8 @@
 
 .radio {
   @include formInput;
-  width: var(--base);
-  height: var(--base);
+  width: 1rem;
+  height: 1rem;
   position: relative;
   padding: 0;
   display: inline-block;
@@ -59,8 +59,8 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: calc(var(--base) / 2);
-    height: calc(var(--base) / 2);
+    width: 0.5rem;
+    height: 0.5rem;
     border-radius: 100%;
     background-color: var(--theme-elevation-800);
     transition: width 0.2s ease, height 0.2s ease;

--- a/src/forms/fields/Select/index.module.scss
+++ b/src/forms/fields/Select/index.module.scss
@@ -60,9 +60,9 @@
     .rs__indicators {
       position: absolute;
       top: 50%;
-      right: var(--base);
+      right: 1rem;
       transform: translate3d(0, -50%, 0);
-      
+
       .arrow {
         transform: rotate(90deg);
       }
@@ -70,12 +70,12 @@
       @include small-break {
         flex-direction: row;
         align-items: center;
-      }      
+      }
     }
 
     .rs__indicator {
       padding: 0px 4px;
-      
+
       svg path {
         fill: var(--theme-elevation-700);
       }
@@ -100,17 +100,17 @@
     }
 
     .rs__menu-list {
-      padding: calc(var(--base) / 4) 0;
+      padding: 0.25rem 0;
       border: 1px solid var(--theme-border-color);
     }
 
     .rs__group-heading {
-      margin-bottom: calc(var(--base) / 2);
+      margin-bottom: 0.5rem;
     }
 
     .rs__option {
       font-size: 1rem;
-      padding: calc(var(--base) / 2) var(--base);
+      padding: 0.5rem 1rem;
 
       &--is-focused {
         background-color: var(--theme-elevation-100);
@@ -136,7 +136,7 @@
     .rs__multi-value__label {
       max-width: 150px;
       color: var(--theme-text);
-      padding: calc(var(--base) / 8) calc(var(--base) / 4);
+      padding: 0.125rem 0.25rem;
     }
 
     .rs__multi-value__remove {
@@ -180,6 +180,6 @@
 
 .description {
     @include small;
-    margin-top: calc(var(--base) / 2);
+    margin-top: 0.5rem;
     color: var(--theme-elevation-400);
 }

--- a/src/forms/fields/Text/index.module.scss
+++ b/src/forms/fields/Text/index.module.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-flex;
   flex-direction: column-reverse;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .fullWidth {
@@ -42,20 +42,20 @@
 .iconWrapper {
   position: absolute;
   top: 50%;
-  right: calc(var(--base) / 1);
+  right: 1rem;
   transform: translate3d(0, -50%, 0);
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: calc(var(--base) / 2);
+  gap: 0.5rem;
 }
 
 .icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: calc(var(--base) / 2);
-  width: calc(var(--base) / 2);
+  height: 0.5rem;
+  width: 0.5rem;
 }
 
 .suffix {

--- a/src/forms/fields/shared.scss
+++ b/src/forms/fields/shared.scss
@@ -9,9 +9,9 @@
   border: 1px solid var(--theme-border-color);
   background: var(--theme-elevation-150);
   color: var(--theme-elevation-800);
-  height: calc(var(--base) * 2.65);
-  line-height: var(--base);
-  padding: calc(var(--base) * 1);
+  height: 2.65rem;
+  line-height: 1rem;
+  padding: 1rem;
 
   &::-moz-placeholder,
   &::-webkit-input-placeholder {
@@ -41,7 +41,7 @@
 
 .description {
   @include small;
-  margin-top: calc(var(--base) / 2);
+  margin-top: 0.5rem;
   color: var(--theme-elevation-400);
 }
 

--- a/src/icons/index.module.scss
+++ b/src/icons/index.module.scss
@@ -1,8 +1,8 @@
 @use "@scss/common" as *;
 
 .icon {
-  width: calc(var(--base) * 0.6);
-  height: calc(var(--base) * 0.6);
+  width: 0.6rem;
+  height: 0.6rem;
   overflow: visible;
   transition: transform var(--default-trans-time) linear;
   will-change: transform;
@@ -21,23 +21,23 @@
 }
 
 .extra-small {
-  width: calc(var(--base) * 0.25);
-  height: calc(var(--base) * 0.25);
+  width: 0.25rem;
+  height: 0.25rem;
 }
 
 .small {
-  width: calc(var(--base) * 0.5);
-  height: calc(var(--base) * 0.5);
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 .medium {
-  height: calc(var(--base) * 0.75);
-  width: calc(var(--base) * 0.75);
+  height: 0.75rem;
+  width: 0.75rem;
 }
 
 .large {
-  height: var(--base);
-  width: var(--base);
+  height: 1rem;
+  width: 1rem;
 }
 
 .full {
@@ -58,6 +58,6 @@
 }
 
 .chevronDown {
-  height: calc(var(--base) * 0.5);
-  width: var(--base);
+  height: 0.5rem;
+  width: 1rem;
 }

--- a/src/providers/HeaderIntersectionObserver/index.module.scss
+++ b/src/providers/HeaderIntersectionObserver/index.module.scss
@@ -1,9 +1,9 @@
 .intersectionObserverDebugger {
-  --center-of-header: calc(calc(var(--header-height) * .5));
+  --center-of-header: calc(calc(var(--header-height) * 0.5));
   position: fixed;
   height: var(--center-of-header);
   width: 100%;
   z-index: 2000;
-  opacity: .5;
+  opacity: 0.5;
   background-color: var(--theme-success-500);
 }

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -44,10 +44,10 @@ export const Providers: React.FC<{
                     xl: '4rem',
                   }}
                   colGap={{
-                    s: 'var(--base)',
-                    m: 'calc(var(--base) * 2)',
-                    l: 'calc(var(--base) * 2)',
-                    xl: 'calc(var(--base) * 3)',
+                    s: '1rem',
+                    m: '2rem',
+                    l: '2rem',
+                    xl: '3rem',
                   }}
                   cols={{
                     s: 8,


### PR DESCRIPTION
Overhauls the CSS site-wide to use `rem` units instead of `var(--base)` and `calc()` expressions. 