### PR TITLE
fix: update cache headers for Vercel Edge network

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   },
   "headers": [
     {
-      "source": "/app/(pages)/(.*)",
+      "source": "/(.*)",
       "headers": [
         {
           "key": "Cache-Control",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
   "github": {
     "silent": true
-  }
+  },
+  "headers": [
+    {
+      "source": "/app/(pages)/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=0, s-maxage=31536000, stale-while-revalidate"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Because we are now using the Payload Local API for data fetching, rather than `fetch()`, our caching relies on the Vercel Edge Network to cache responses and. This PR updates the cache strategy in our Vercel Edge Network configuration to cache functions for much longer to prevent cache writes for every page visit.