### PR TITLE
adds noindex checkbox to pages

### DIFF
--- a/src/app/(frontend)/(pages)/[...slug]/page.tsx
+++ b/src/app/(frontend)/(pages)/[...slug]/page.tsx
@@ -62,6 +62,9 @@ export async function generateMetadata({
     'url' in page?.meta?.image &&
     `${process.env.NEXT_PUBLIC_CMS_URL}${page.meta.image.url}`
 
+  // check if noIndex is true
+  const noIndexMeta = page?.noindex ? { robots: 'noindex' } : {}
+
   return {
     title: page?.meta?.title || 'Payload',
     description: page?.meta?.description,
@@ -77,5 +80,6 @@ export async function generateMetadata({
           ]
         : undefined,
     }),
+    ...noIndexMeta, // Add noindex meta tag if noindex is true
   }
 }

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -58,6 +58,14 @@ export const Pages: CollectionConfig = {
     },
     fullTitle,
     {
+      type: 'checkbox',
+      name: 'noindex',
+      label: 'No Index',
+      admin: {
+        position: 'sidebar'
+      }
+    },
+    {
       type: 'tabs',
       tabs: [
         {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1553,6 +1553,7 @@ export interface Page {
   id: string;
   title: string;
   fullTitle?: string | null;
+  noindex?: boolean | null;
   hero: {
     type: 'default' | 'contentMedia' | 'centeredContent' | 'form' | 'home' | 'livestream' | 'gradient' | 'three';
     fullBackground?: boolean | null;


### PR DESCRIPTION
This will allow us to hide specific pages from Google, other crawlers, etc. 

- Added a `noindex` checkbox to Pages collection
- If checked, the meta property will get added to the `<head>` element accordingly