### PR TITLE
feat: match search hit urls to docs version

### DIFF
--- a/src/components/Header/Docsearch/Component.tsx
+++ b/src/components/Header/Docsearch/Component.tsx
@@ -1,24 +1,33 @@
 import { DocSearch } from '@docsearch/react'
+import { usePathname } from 'next/navigation'
 import React from 'react'
 
 import classes from './index.module.scss'
 
-function Hit({ children, hit }) {
+function Hit({ children, hit, path }) {
   const blog = hit?.url?.includes('/blog/') || false
+
+  let url = hit?.url
+
+  if (path.includes('/docs/v2/')) {
+    url = url.replace('/docs/', '/docs/v2/')
+  }
+
   return (
-    <a className={blog ? classes.blogResult : ''} href={hit?.url}>
+    <a className={blog ? classes.blogResult : ''} href={url}>
       {children}
     </a>
   )
 }
 
 function Component() {
+  const path = usePathname()
   return (
     // @ts-expect-error
     <DocSearch
       apiKey={process.env.NEXT_PUBLIC_ALGOLIA_DOCSEARCH_KEY || ''}
       appId="9MJY7K9GOW"
-      hitComponent={Hit}
+      hitComponent={({ children, hit }) => Hit({ children, hit, path })}
       indexName="payloadcms"
     />
   )


### PR DESCRIPTION
If searching for docs, the search hits link to latest documentation regardless of which version of the docs you are currently viewing. This PR modifies the search component to check if the user is currently viewing V2 docs, and modify the hit url to point to the respective V2 docs.

This is a quick solution to let users maintain versions while utilizing search. In the future, we should consider a crawling strategy for versioned docs with the ability to select specific versions, as well as maintaining a user's version preference.