### PR TITLE
fix: correctly return 404 for docs routes

### DIFF
--- a/src/components/RenderDocs/index.tsx
+++ b/src/components/RenderDocs/index.tsx
@@ -49,11 +49,11 @@ export const RenderDocs = async ({
 
   const currentDoc = topic?.docs?.[docIndex]
 
-  const path = `${topic.slug.toLowerCase()}/${currentDoc.slug}`
-
   if (!currentDoc) {
     return notFound()
   }
+
+  const path = `${topic.slug.toLowerCase()}/${currentDoc.slug}`
 
   const hideVersionSelector =
     process.env.NEXT_PUBLIC_ENABLE_BETA_DOCS !== 'true' &&


### PR DESCRIPTION
Previously we were trying to assign a `path` variable with data that did not exist for missing routes. This PR makes it so we return `notFound` before trying to assign `path`.

Fixes payloadcms/payload#9624