### PR TITLE
fix: pagination on cloud import repo page

### DIFF
--- a/src/app/(frontend)/(cloud)/new/import/page_client.tsx
+++ b/src/app/(frontend)/(cloud)/new/import/page_client.tsx
@@ -227,11 +227,11 @@ export const ImportProject: React.FC<{
             </Fragment>
           )}
         </div>
-        {installs?.length > 0 && results?.total_count / perPage > 1 && (
+        {installs?.length > 0 && initialRepos && initialRepos?.total_count > perPage && (
           <Pagination
             page={page}
             setPage={setPage}
-            totalPages={Math.ceil(results?.total_count / perPage)}
+            totalPages={Math.ceil(initialRepos?.total_count / perPage)}
             className={classes.pagination}
           />
         )}

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,15 +1,14 @@
-import * as React from 'react'
-
 import { ChevronIcon } from '@root/icons/ChevronIcon/index.js'
+import * as React from 'react'
 
 import classes from './index.module.scss'
 
 export const Pagination: React.FC<{
+  className?: string
   page: number
   setPage: (page: number) => void
   totalPages: number
-  className?: string
-}> = ({ page, setPage, totalPages, className }) => {
+}> = ({ className, page, setPage, totalPages }) => {
   const [indexToShow, setIndexToShow] = React.useState([0, 1, 2, 3, 4])
   const showFirstPage = totalPages > 5 && page >= 2
   const showLastPage = totalPages > 5 && page <= totalPages - 3
@@ -35,19 +34,19 @@ export const Pagination: React.FC<{
   return (
     <div className={[classes.pagination, className].filter(Boolean).join(' ')}>
       {showFirstPage && (
-        <>
+        <React.Fragment>
           <button
-            type="button"
             className={classes.paginationButton}
             onClick={() => {
               window.scrollTo(0, 0)
               setPage(1)
             }}
+            type="button"
           >
             1
           </button>
           <div className={classes.dash}>&mdash;</div>
-        </>
+        </React.Fragment>
       )}
       {[...Array(totalPages)].map((_, index) => {
         const currentPage = index + 1
@@ -57,7 +56,6 @@ export const Pagination: React.FC<{
           return (
             <div key={index}>
               <button
-                type="button"
                 className={[
                   classes.paginationButton,
                   isCurrent && classes.paginationButtonActive,
@@ -69,6 +67,7 @@ export const Pagination: React.FC<{
                   window.scrollTo(0, 0)
                   setPage(currentPage)
                 }}
+                type="button"
               >
                 {currentPage}
               </button>
@@ -76,10 +75,9 @@ export const Pagination: React.FC<{
           )
       })}
       {showLastPage && (
-        <>
+        <React.Fragment>
           <div className={classes.dash}>&mdash;</div>
           <button
-            type="button"
             className={classes.paginationButton}
             onClick={() => {
               setTimeout(() => {
@@ -87,23 +85,28 @@ export const Pagination: React.FC<{
               }, 0)
               setPage(totalPages)
             }}
+            type="button"
           >
             {totalPages}
           </button>
-        </>
+        </React.Fragment>
       )}
       <button
+        className={[classes.button, page - 1 < 1 && classes.disabled].filter(Boolean).join(' ')}
         disabled={page - 1 < 1}
         onClick={() => {
           if (page - 1 < 1) return
           window.scrollTo(0, 0)
           setPage(page > 1 ? page - 1 : 1)
         }}
-        className={[classes.button, page - 1 < 1 && classes.disabled].filter(Boolean).join(' ')}
+        type="button"
       >
         <ChevronIcon rotation={180} />
       </button>
       <button
+        className={[classes.button, page + 1 > totalPages && classes.disabled]
+          .filter(Boolean)
+          .join(' ')}
         disabled={page + 1 > totalPages}
         onClick={() => {
           if (page + 1 > totalPages) return
@@ -111,9 +114,7 @@ export const Pagination: React.FC<{
           window.scrollTo(0, 0)
           setPage(page + 1)
         }}
-        className={[classes.button, page + 1 > totalPages && classes.disabled]
-          .filter(Boolean)
-          .join(' ')}
+        type="button"
       >
         <ChevronIcon />
       </button>


### PR DESCRIPTION
Previously we were checking the `total_count` value of `results`, which is always the same as the `perPage` value. This PR adjusts the logic to render the pagination component based on `initialRepos.total_count`, which will include all repos.

Also add's `type="button"` to the arrow buttons in the pagination component, which were otherwise trying to submit the form.