### PR TITLE
add mdx field to docs

### DIFF
--- a/src/collections/Docs/index.ts
+++ b/src/collections/Docs/index.ts
@@ -187,6 +187,14 @@ export const Docs: CollectionConfig = {
         },
       ],
     },
+    {
+      name: 'mdx',
+      type: 'textarea',
+      admin: {
+        hidden: true,
+      },
+      maxLength: Number.MAX_SAFE_INTEGER,
+    },
   ],
   hooks: {
     afterRead: [

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -5160,6 +5160,7 @@ export interface Doc {
   label?: string | null;
   order?: number | null;
   version: string;
+  mdx?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -6409,6 +6410,7 @@ export interface DocsSelect<T extends boolean = true> {
   label?: T;
   order?: T;
   version?: T;
+  mdx?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/scripts/syncDocs.ts
+++ b/src/scripts/syncDocs.ts
@@ -40,6 +40,7 @@ export const topicGroupsToDocsData: (args: {
           headings: doc.headings,
           keywords: doc.keywords,
           label: doc.label,
+          mdx,
           order: doc.order,
           path: `${topic.slug}/${doc.slug}`,
           title: doc.title,


### PR DESCRIPTION
The mdx <-> Lexical conversion is a somewhat immature feature that still needs to be tested and polished.

At least for now, we are adding a column containing the mdx to the docs collection.

This will help with debugging and testing the conversion. Also, we can refresh the conversion to editorState without fetching every time.  That is what we are doing now, causing the Github API rate limit to be exceeded easily and frequently.