### PR TITLE
Add ability to refresh mdx to lexical conversion.

### DIFF
--- a/src/components/AfterNavActions/index.tsx
+++ b/src/components/AfterNavActions/index.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import React from 'react'
-
-import SyncDocsButton from '@components/SyncDocsButton'
-import SyncCommunityHelp from '@components/SyncCommunityHelp'
 import RedeployButton from '@components/RedeployButton'
+import RefreshMdxToLexicalButton from '@components/RefreshMdxToLexicalButton'
+import SyncCommunityHelp from '@components/SyncCommunityHelp'
+import SyncDocsButton from '@components/SyncDocsButton'
 
 import './index.scss'
+
+import React from 'react'
 
 const baseClass = 'after-nav-actions'
 
@@ -15,6 +16,7 @@ const AfterNavActions: React.FC = () => {
     <div className={baseClass}>
       <span className={`${baseClass}__group-title`}>Admin Actions</span>
       <SyncDocsButton />
+      <RefreshMdxToLexicalButton />
       <SyncCommunityHelp />
       <RedeployButton />
     </div>

--- a/src/components/RefreshMdxToLexicalButton/index.scss
+++ b/src/components/RefreshMdxToLexicalButton/index.scss
@@ -1,0 +1,16 @@
+@use '~@payloadcms/ui/scss';
+
+.refresh-docs-button {
+  @extend %btn-reset;
+  padding-top: base(0.75);
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}

--- a/src/components/RefreshMdxToLexicalButton/index.tsx
+++ b/src/components/RefreshMdxToLexicalButton/index.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { toast, useConfig } from '@payloadcms/ui'
+import React, { useState } from 'react'
+
+import './index.scss'
+
+const baseClass = 'refresh-docs-button'
+
+const RefreshMdxToLexicalButton: React.FC = () => {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const {
+    config: {
+      routes: { api },
+    },
+  } = useConfig()
+
+  const refreshDocs = async () => {
+    setIsRefreshing(true)
+    const res = await fetch(`${api}/refresh/mdx-to-lexical`)
+    if (res.ok) {
+      toast.success('Documentation refreshed successfully')
+      setIsRefreshing(false)
+    } else {
+      const data = await res.json()
+      toast.error(`Failed to refresh documentation: ${data.message}`)
+      setIsRefreshing(false)
+    }
+  }
+
+  return (
+    <button className={baseClass} disabled={isRefreshing} onClick={refreshDocs} type="button">
+      {isRefreshing ? 'Refreshing...' : 'Refresh MDX to Lexical'}
+    </button>
+  )
+}
+
+export default RefreshMdxToLexicalButton

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -39,7 +39,7 @@ import { GetStarted } from './globals/GetStarted'
 import { MainMenu } from './globals/MainMenu'
 import { PartnerProgram } from './globals/PartnerProgram'
 import redeployWebsite from './scripts/redeployWebsite'
-import { syncDocs } from './scripts/syncDocs'
+import { refreshMdxToLexical, syncDocs } from './scripts/syncDocs'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -245,6 +245,11 @@ export default buildConfig({
       handler: redeployWebsite,
       method: 'post',
       path: '/redeploy/website',
+    },
+    {
+      handler: refreshMdxToLexical,
+      method: 'get',
+      path: '/refresh/mdx-to-lexical',
     },
   ],
   globals: [Footer, MainMenu, GetStarted, PartnerProgram],


### PR DESCRIPTION
This is a continuation of https://github.com/payloadcms/website/pull/419
Add ability to refresh mdx to lexical conversion without the need to fetch again from Github.
Useful for debugging and polishing our converters.