### PR TITLE
fix: partners page prerender error by adding data existence check

### DIFF
--- a/src/app/(frontend)/(pages)/partners/page.tsx
+++ b/src/app/(frontend)/(pages)/partners/page.tsx
@@ -35,6 +35,31 @@ export default async function Partners() {
 
   const getPartners = draft ? fetchPartners : unstable_cache(fetchPartners, ['partners'])
   const partners = await getPartners()
+
+  // Check if partners exists
+  if (!partners || partners.length === 0) {
+    return (
+      <BlockWrapper settings={{}}>
+        <BreadcrumbsBar
+          breadcrumbs={[
+            {
+              label: 'Agency Partners',
+            },
+          ]}
+          links={[
+            {
+              label: 'Become a Partner',
+              url: '/partners',
+            },
+          ]}
+        />
+        <Gutter className={[classes.hero, 'grid'].join(' ')}>
+          <p>No partners available at the moment.</p>
+        </Gutter>
+      </BlockWrapper>
+    )
+  }
+
   const partnerList = partners.map((partner) => {
     return {
       ...partner,


### PR DESCRIPTION
This caused partners and partnerProgram to return undefined or null values ​​when no "partners" data had been created in the dashboard. Attempting to access properties of these undefined data (e.g. .map()) would trigger an error when the page was rendered.
` ✓ Collecting page data 
Error occurred prerendering page "/partners". Read more: https://nextjs.org/docs/messages/prerender-error
TypeError: Cannot read properties of undefined (reading 'map')
    at v (.next/server/app/(frontend)/(pages)/partners/page.js:1:14910)`