### PR TITLE
fix: duplicate key issue in PartnerGrid component

### DIFF
--- a/src/components/PartnerGrid/index.tsx
+++ b/src/components/PartnerGrid/index.tsx
@@ -16,7 +16,7 @@ export const PartnerGrid = (props: PartnerGridProps) => {
       {partners.map((partner) => {
         return (
           typeof partner !== 'string' && (
-            <PartnerCard {...partner} key={partner.id + featured ? '_featured' : ''} />
+            <PartnerCard {...partner} key={partner.id + (featured ? '_featured' : '')} />
           )
         )
       })}


### PR DESCRIPTION
`Console Error
Encountered two children with the same key, _featured. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.`