### PR TITLE
fix: makes doc dir before writing to it and adds to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+/src/docs
+
 # dependencies
 /node_modules
 /.pnp

--- a/scripts/fetch-docs.mjs
+++ b/scripts/fetch-docs.mjs
@@ -185,6 +185,12 @@ async function fetchDocs() {
   const data = JSON.stringify(topics.filter(Boolean), null, 2)
   const docsFilename = path.resolve(__dirname, outputDirectory)
 
+  const dir = path.dirname(docsFilename)
+  
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+
   fs.writeFile(docsFilename, data, (err) => {
     if (err) {
       console.error(err)


### PR DESCRIPTION
When writing docs, if you do not already have a `/src/docs` directory, the script would fail while attempting to write to it. Now it checks for that directory and creates one if needed. The reason this could happen is because that directory is ignored from git, and so unless you've previously written to it, you will not have this directory on your machine.