### PR TITLE
feat: adds custom components topic to sidebar

### DIFF
--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -12,6 +12,7 @@ export const topicOrder = {
       groupLabel: 'Features',
       topics: [
         'Admin',
+        'Custom-Components',
         'Authentication',
         'Rich-Text',
         'Live-Preview',


### PR DESCRIPTION
Adds a new topic to the docs sidebar under the "Features" group labeled "Custom Components". This will be the new location for all custom components, with the exception of fields, and will include code snippets outlining how to build each one with explicitly types.