### PR TITLE
feat: local docs

### DIFF
--- a/scripts/fetch-docs.mjs
+++ b/scripts/fetch-docs.mjs
@@ -64,11 +64,12 @@ function getHeadings(source) {
 
 function getLocalDocsPath() {
   const nodeModuleDocsPath = path.join(process.cwd(), './node_modules/payload/docs')
-  console.log(process.env.DOCS_DIR_V3)
+
   const docDirs = {
     v2: process.env.DOCS_DIR_V2 ? path.resolve(process.env.DOCS_DIR_V2) : nodeModuleDocsPath,
     v3: process.env.DOCS_DIR_V3 ? path.resolve(process.env.DOCS_DIR_V3) : nodeModuleDocsPath,
   }
+
   return docDirs?.[ref] || nodeModuleDocsPath
 }
 

--- a/scripts/fetch-docs.mjs
+++ b/scripts/fetch-docs.mjs
@@ -64,6 +64,7 @@ function getHeadings(source) {
 
 function getLocalDocsPath() {
   const nodeModuleDocsPath = path.join(process.cwd(), './node_modules/payload/docs')
+  console.log(process.env.DOCS_DIR_V3)
   const docDirs = {
     v2: process.env.DOCS_DIR_V2 ? path.resolve(process.env.DOCS_DIR_V2) : nodeModuleDocsPath,
     v3: process.env.DOCS_DIR_V3 ? path.resolve(process.env.DOCS_DIR_V3) : nodeModuleDocsPath,
@@ -186,7 +187,7 @@ async function fetchDocs() {
   const docsFilename = path.resolve(__dirname, outputDirectory)
 
   const dir = path.dirname(docsFilename)
-  
+
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true })
   }

--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -12,6 +12,7 @@ export const topicOrder = {
       groupLabel: 'Features',
       topics: [
         'Admin',
+        'Custom-Components',
         'Authentication',
         'Rich-Text',
         'Live-Preview',

--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -12,7 +12,6 @@ export const topicOrder = {
       groupLabel: 'Features',
       topics: [
         'Admin',
-        'Custom-Components',
         'Authentication',
         'Rich-Text',
         'Live-Preview',

--- a/src/app/(frontend)/(pages)/docs/dynamic/[topic]/[doc]/page.tsx
+++ b/src/app/(frontend)/(pages)/docs/dynamic/[topic]/[doc]/page.tsx
@@ -89,6 +89,7 @@ export default async function DocsPage(args: {
     topicGroup: curTopicGroup.groupLabel,
     version: branch,
   }
+
   if (!curDoc) {
     notFound()
   }

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/api.ts
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/api.ts
@@ -20,10 +20,18 @@ export type Doc = {
 }
 
 export const fetchLocalDocs = (ref?: 'v2' | 'v3'): TopicGroup[] => {
-  const topics =
-    ref === 'v2'
-      ? require('../../../../../../../docs/docs-v2.json')
-      : require('../../../../../../../docs/docs-v3.json')
+  let topics: TopicGroup[] = []
 
-  return topics as TopicGroup[]
+  if (process.env.NODE_ENV !== 'production') {
+    try {
+      topics =
+        ref === 'v2'
+          ? require('../../../../../../../docs/docs-v2.json')
+          : require('../../../../../../../docs/docs-v3.json')
+    } catch (_err) {
+      console.error('Error fetching local docs', _err) // eslint-disable-line no-console
+    }
+  }
+
+  return topics
 }

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/api.ts
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/api.ts
@@ -1,0 +1,29 @@
+export type Topic = {
+  docs: Doc[]
+  slug: string
+}
+
+export type TopicGroup = {
+  groupLabel: string
+  topics: Topic[]
+}
+
+export type Doc = {
+  content: string
+  desc: any
+  headings: any
+  keywords: any
+  label: any
+  order: any
+  slug: string
+  title: any
+}
+
+export const fetchLocalDocs = (ref?: 'v2' | 'v3'): TopicGroup[] => {
+  const topics =
+    ref === 'v2'
+      ? require('../../../../../../../docs/docs-v2.json')
+      : require('../../../../../../../docs/docs-v3.json')
+
+  return topics as TopicGroup[]
+}

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/layout.tsx
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/layout.tsx
@@ -1,0 +1,28 @@
+import { Footer } from '@components/Footer/index.js'
+import { Header } from '@components/Header/index.js'
+import { fetchGlobals } from '@data/index.js'
+import { unstable_cache } from 'next/cache'
+import { draftMode } from 'next/headers.js'
+import React from 'react'
+
+export const dynamic = 'auto'
+
+export default async function Layout({ children }: { children: React.ReactNode }) {
+  const { isEnabled: draft } = await draftMode()
+  const getGlobals = draft
+    ? fetchGlobals
+    : unstable_cache(fetchGlobals, ['globals', 'mainMenu', 'footer'])
+
+  const { footer, mainMenu } = await getGlobals()
+
+  return (
+    <React.Fragment>
+      <Header {...mainMenu} />
+      <div>
+        {children}
+        <div id="docsearch" />
+        <Footer {...footer} />
+      </div>
+    </React.Fragment>
+  )
+}

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next'
+
+import { Banner } from '@components/Banner'
+
+/* eslint-disable no-restricted-exports */
+import { RenderDocs } from '@components/RenderDocs'
+import config from '@payload-config'
+import { sanitizeServerEditorConfig } from '@payloadcms/richtext-lexical'
+import { contentLexicalEditorFeatures } from '@root/collections/Docs'
+import { mdxToLexical } from '@root/collections/Docs/mdxToLexical'
+import { headers } from 'next/headers'
+import { notFound } from 'next/navigation'
+import { getPayload, type RequiredDataFromCollectionSlug } from 'payload'
+import React from 'react'
+
+import { fetchLocalDocs } from './api'
+
+export type TopicsOrder = { topics: string[] }[]
+
+type Params = { doc: string; topic: string }
+
+export default async function DocsPage(args: {
+  params: Promise<Params>
+  searchParams: Promise<{
+    branch: string
+  }>
+}) {
+  await headers()
+  const { params } = args
+  const { doc: docSlug, topic: topicSlug } = await params
+  const payload = await getPayload({ config })
+
+  const topics = fetchLocalDocs()
+
+  const groupIndex = topics.findIndex(({ topics: tGroup }) =>
+    tGroup.some((topic) => topic?.slug?.toLowerCase() === topicSlug),
+  )
+
+  const indexInGroup = topics[groupIndex]?.topics?.findIndex(
+    (topic) => topic?.slug?.toLowerCase() === topicSlug,
+  )
+
+  const topicGroup = topics?.[groupIndex]
+
+  const topic = topicGroup?.topics?.[indexInGroup]
+
+  const docIndex = topic?.docs.findIndex((doc) => doc.slug.replace('.mdx', '') === docSlug)
+
+  const curParsedDoc = topic?.docs?.[docIndex]
+
+  if (!curParsedDoc) {
+    notFound()
+  }
+
+  const mdx = curParsedDoc.content
+
+  const editorConfig = await sanitizeServerEditorConfig(
+    {
+      features: contentLexicalEditorFeatures,
+    },
+    payload.config,
+  )
+
+  const { editorState } = mdxToLexical({
+    editorConfig,
+    mdx,
+  })
+
+  const curDoc: RequiredDataFromCollectionSlug<'docs'> = {
+    slug: curParsedDoc.slug,
+    content: editorState as any,
+    description: curParsedDoc.desc,
+    headings: curParsedDoc.headings,
+    keywords: curParsedDoc.keywords,
+    label: curParsedDoc.label,
+    order: curParsedDoc.order,
+    path: `${topic.slug}/${curParsedDoc.slug}`,
+    title: curParsedDoc.title,
+    topic: topic.slug,
+    topicGroup: topicGroup.groupLabel,
+    // version: branch,
+  }
+  if (!curDoc) {
+    notFound()
+  }
+
+  return (
+    <>
+      <RenderDocs
+        currentDoc={curDoc as any}
+        docSlug={docSlug}
+        topicGroups={topics}
+        topicSlug={topicSlug}
+        version="dynamic"
+      >
+        <Banner type="warning">
+          You are currently viewing documentation from your local repository.
+        </Banner>
+      </RenderDocs>
+    </>
+  )
+}
+
+export const metadata: Metadata = {
+  robots: 'noindex, nofollow',
+}

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
@@ -78,7 +78,7 @@ export default async function DocsPage(args: {
     title: curParsedDoc.title,
     topic: topic.slug,
     topicGroup: topicGroup.groupLabel,
-    // version: branch,
+    version: 'local',
   }
 
   if (!curDoc) {
@@ -90,6 +90,7 @@ export default async function DocsPage(args: {
       <RenderDocs
         currentDoc={curDoc as any}
         docSlug={docSlug}
+        // @ts-expect-error // TODO: fix this type
         topicGroups={topics}
         topicSlug={topicSlug}
         version="local"

--- a/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
+++ b/src/app/(frontend)/(pages)/docs/local/[topic]/[doc]/page.tsx
@@ -80,6 +80,7 @@ export default async function DocsPage(args: {
     topicGroup: topicGroup.groupLabel,
     // version: branch,
   }
+
   if (!curDoc) {
     notFound()
   }
@@ -91,7 +92,7 @@ export default async function DocsPage(args: {
         docSlug={docSlug}
         topicGroups={topics}
         topicSlug={topicSlug}
-        version="dynamic"
+        version="local"
       >
         <Banner type="warning">
           You are currently viewing documentation from your local repository.

--- a/src/components/DocsNavigation/index.tsx
+++ b/src/components/DocsNavigation/index.tsx
@@ -167,7 +167,7 @@ export const DocsNavigation = ({
                             topicRefs.current[`${groupIndex}-${index}`] = ref
                           }}
                         >
-                          {topic.label.replace('-', ' ')}
+                          {topic.label?.replace('-', ' ')}
                           <ChevronIcon aria-hidden className={classes.chevron} size="small" />
                         </Accordion.Trigger>
                         <Accordion.Content asChild>

--- a/src/components/DocsNavigation/index.tsx
+++ b/src/components/DocsNavigation/index.tsx
@@ -1,4 +1,6 @@
 'use client'
+import type { DocsVersion } from '@components/RenderDocs'
+
 import { MenuIcon } from '@graphics/MenuIcon'
 import * as Accordion from '@radix-ui/react-accordion'
 import * as Portal from '@radix-ui/react-portal'
@@ -29,7 +31,7 @@ export const DocsNavigation = ({
   groupIndex: number
   indexInGroup: number
   topics: TopicGroupForNav[]
-  version?: 'beta' | 'current' | 'dynamic' | 'v2'
+  version?: DocsVersion
 }) => {
   const [currentTopicIsOpen, setCurrentTopicIsOpen] = useState(true)
   const [openTopicPreferences, setOpenTopicPreferences] = useState<string[]>()
@@ -167,7 +169,7 @@ export const DocsNavigation = ({
                             topicRefs.current[`${groupIndex}-${index}`] = ref
                           }}
                         >
-                          {topic.label?.replace('-', ' ')}
+                          {(topic.label || topic.slug)?.replace('-', ' ')}
                           <ChevronIcon aria-hidden className={classes.chevron} size="small" />
                         </Accordion.Trigger>
                         <Accordion.Content asChild>

--- a/src/components/RenderDocs/index.tsx
+++ b/src/components/RenderDocs/index.tsx
@@ -56,14 +56,15 @@ export const RenderDocs = async ({
 
   const topicGroup = topicGroups?.find(
     ({ groupLabel, topics }) =>
-      topics.some((topic) => topic.slug === topicSlug) && groupLabel === currentDoc.topicGroup,
+      topics.some((topic) => topic.slug.toLowerCase() === topicSlug) &&
+      groupLabel === currentDoc.topicGroup,
   )
 
   if (!topicGroup) {
     throw new Error('Topic group not found')
   }
 
-  const topic = topicGroup.topics.find((topic) => topic.slug === topicSlug)
+  const topic = topicGroup.topics.find((topic) => topic.slug.toLowerCase() === topicSlug)
 
   if (!topic) {
     throw new Error('Topic not found')

--- a/src/components/RenderDocs/index.tsx
+++ b/src/components/RenderDocs/index.tsx
@@ -21,6 +21,8 @@ import React, { Suspense } from 'react'
 
 import classes from './index.module.scss'
 
+export type DocsVersion = 'beta' | 'current' | 'dynamic' | 'local' | 'v2'
+
 export const RenderDocs = async ({
   children,
   currentDoc,
@@ -34,7 +36,7 @@ export const RenderDocs = async ({
   docSlug: string
   topicGroups: TopicGroupForNav[]
   topicSlug: string
-  version?: 'beta' | 'current' | 'dynamic' | 'v2'
+  version?: DocsVersion
 }) => {
   const groupIndex = topicGroups.findIndex(({ topics: tGroup }) =>
     tGroup.some((topic) => topic?.slug?.toLowerCase() === topicSlug.toLowerCase()),

--- a/src/components/VersionSelector/index.tsx
+++ b/src/components/VersionSelector/index.tsx
@@ -1,4 +1,6 @@
 'use client'
+import type { DocsVersion } from '@components/RenderDocs'
+
 import { ChevronUpDownIcon } from '@root/icons/ChevronUpDownIcon/index.js'
 import { useRouter } from 'next/navigation'
 import React from 'react'
@@ -6,7 +8,7 @@ import React from 'react'
 import classes from './index.module.scss'
 
 export const VersionSelector: React.FC<{
-  initialVersion: 'beta' | 'current' | 'dynamic' | 'v2'
+  initialVersion: DocsVersion
 }> = ({ initialVersion }) => {
   const router = useRouter()
 


### PR DESCRIPTION
Brings back the ability to preview docs from a local repository, bypassing the need to save docs as records in the database. Does by so querying the `payload` repository from your local file system and traversing the `docs` directory. This will output a json file containing all mdx markup which is converted to Lexical before rendering.