### PR TITLE
feat: adds custom components docs topic

### DIFF
--- a/scripts/shared.mjs
+++ b/scripts/shared.mjs
@@ -12,6 +12,7 @@ export const topicOrder = {
       groupLabel: 'Features',
       topics: [
         'Admin',
+        'Custom-Components',
         'Authentication',
         'Rich-Text',
         'Live-Preview',


### PR DESCRIPTION
Adds a new "Custom Components" topic to the docs nav to facilitate the changes made here: https://github.com/payloadcms/payload/pull/10987