### PR TITLE
fix: disable code wrapping, allow max. 1 open nav

### DIFF
--- a/src/components/Code/index.tsx
+++ b/src/components/Code/index.tsx
@@ -75,6 +75,7 @@ const Code: React.FC<Props> = (props) => {
         classes.codeWrap,
         disableMinHeight && classes.disableMinHeight,
         parentClassName && parentClassName,
+        'code-block-wrap',
       ]
         .filter(Boolean)
         .join(' ')}

--- a/src/components/DocsNavigation/index.tsx
+++ b/src/components/DocsNavigation/index.tsx
@@ -143,11 +143,11 @@ export const DocsNavigation = ({
             </div>
           )}
           <Accordion.Root
-            defaultValue={[...openTopicPreferences, currentTopic]}
+            defaultValue={currentTopic}
             onValueChange={(value) =>
               window.localStorage.setItem(openTopicsLocalStorageKey, JSON.stringify(value))
             }
-            type="multiple"
+            type="single"
           >
             {topics.map((tGroup, groupIndex) => (
               <Fragment key={`group-${groupIndex}`}>

--- a/src/components/RichText/index.scss
+++ b/src/components/RichText/index.scss
@@ -22,6 +22,10 @@
     white-space: pre-wrap;
   }
 
+  .code-block-wrap span {
+    white-space: unset;
+  }
+
   .lexical-table-container {
     overflow: auto;
     margin-bottom: 2rem;


### PR DESCRIPTION
- Disables code wrapping, which can make them very hard to read

Before:
![image](https://github.com/user-attachments/assets/ad9f0d33-96b7-4749-9394-167c16cf3e62)


After:
![image](https://github.com/user-attachments/assets/0f347981-2b35-4dae-99b1-3a0dcf1bab7f)


- Allows max. 1 nav item open. Having multiple nav groups open makes it difficult to find stuff, and closing them requires manually clicking every open nav group header.

Before:
![CleanShot 2025-03-13 at 18 01 12@2x](https://github.com/user-attachments/assets/c30d898b-e539-4a3c-a22e-b88b7e0151ca)

After:
![CleanShot 2025-03-13 at 18 01 22@2x](https://github.com/user-attachments/assets/25ce3461-3c42-4bdb-afbc-a31183d21293)
