### PR TITLE
fix: use tsx instead of jsx for code block rendering

### DIFF
--- a/src/components/Code/index.tsx
+++ b/src/components/Code/index.tsx
@@ -81,7 +81,7 @@ const Code: React.FC<Props> = (props) => {
         .join(' ')}
       data-theme={'dark'}
     >
-      <Highlight code={children} language="jsx" theme={theme}>
+      <Highlight code={children} language="tsx" theme={theme}>
         {({ getLineProps, getTokenProps, style, tokens }) => (
           <div className={classNames} style={style}>
             {tokens


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/54ed5da7-2f63-483e-acda-186884e69930)


After
![image](https://github.com/user-attachments/assets/0f87e0b9-4ccd-4eb0-9ffe-c1002680178c)
