### PR TITLE
Feat: add Resources block to docs

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -34,6 +34,7 @@ import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c08
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { SaveButtonClient as SaveButtonClient_259d8f559cb11a4167281a913f510f62 } from '@root/collections/Docs/SaveButton'
 import { BranchButton as BranchButton_a056620e50cdeec34262a2e060477165 } from '@root/collections/Docs/BranchButton'
+import { Label as Label_087cde4d1fde05040831b5843a5fb654 } from '@root/fields/addToDocs/Label'
 import { default as default_7855b44454994335ecfbd19f80d2bb90 } from '@root/globals/CustomRowLabelNavItems'
 import { default as default_7b4b356d4f495796f5ea32368107862c } from '@root/globals/CustomRowLabelTabs'
 import { BlogMarkdownField as BlogMarkdownField_a0e4da4b38919785352cf36efa721675 } from '@root/blocks/BlogMarkdown/Field'
@@ -78,6 +79,7 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@root/collections/Docs/SaveButton#SaveButtonClient": SaveButtonClient_259d8f559cb11a4167281a913f510f62,
   "@root/collections/Docs/BranchButton#BranchButton": BranchButton_a056620e50cdeec34262a2e060477165,
+  "@root/fields/addToDocs/Label#Label": Label_087cde4d1fde05040831b5843a5fb654,
   "@root/globals/CustomRowLabelNavItems#default": default_7855b44454994335ecfbd19f80d2bb90,
   "@root/globals/CustomRowLabelTabs#default": default_7b4b356d4f495796f5ea32368107862c,
   "@root/blocks/BlogMarkdown/Field#BlogMarkdownField": BlogMarkdownField_a0e4da4b38919785352cf36efa721675,

--- a/src/collections/Docs/blocks/resource/index.ts
+++ b/src/collections/Docs/blocks/resource/index.ts
@@ -4,8 +4,9 @@ export const ResourceBlock: Block = {
   slug: 'Resource',
   fields: [
     {
-      name: 'id',
-      type: 'text',
+      name: 'post',
+      type: 'relationship',
+      relationTo: 'posts',
     },
   ],
   interfaceName: 'ResourceBlock',
@@ -13,13 +14,13 @@ export const ResourceBlock: Block = {
     export({ fields }) {
       return {
         props: {
-          id: fields.id,
+          id: fields.post,
         },
       }
     },
     import({ props }) {
       return {
-        id: props.id,
+        post: props.id,
       }
     },
   },

--- a/src/collections/Docs/blocks/resource/index.ts
+++ b/src/collections/Docs/blocks/resource/index.ts
@@ -1,0 +1,26 @@
+import type { Block } from 'payload'
+
+export const ResourceBlock: Block = {
+  slug: 'Resource',
+  fields: [
+    {
+      name: 'id',
+      type: 'text',
+    },
+  ],
+  interfaceName: 'ResourceBlock',
+  jsx: {
+    export({ fields }) {
+      return {
+        props: {
+          id: fields.id,
+        },
+      }
+    },
+    import({ props }) {
+      return {
+        id: props.id,
+      }
+    },
+  },
+}

--- a/src/collections/Docs/index.ts
+++ b/src/collections/Docs/index.ts
@@ -48,6 +48,7 @@ export const contentLexicalEditorFeatures: FeatureProviderServer[] = [
       'LightDarkImage',
       'Upload',
       'RestExamples',
+      'Resource',
       'TableWithDrawers',
       'VideoDrawer',
     ],

--- a/src/collections/Posts.ts
+++ b/src/collections/Posts.ts
@@ -1,5 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
+import { addToDocs } from '@root/fields/addToDocs'
 import { revalidatePath } from 'next/cache'
 
 import { isAdmin } from '../access/isAdmin'
@@ -309,6 +310,7 @@ export const Posts: CollectionConfig = {
       },
       required: true,
     },
+    addToDocs,
   ],
   forceSelect: {
     relatedPosts: true,

--- a/src/components/Drawer/types.ts
+++ b/src/components/Drawer/types.ts
@@ -8,7 +8,7 @@ export interface Props {
   size?: 'l' | 'm' | 's'
   slug: string
 
-  title?: string
+  title?: React.ReactNode | string
 }
 
 export type TogglerProps = {

--- a/src/components/RichText/ResourceBlock/index.module.scss
+++ b/src/components/RichText/ResourceBlock/index.module.scss
@@ -1,0 +1,128 @@
+@use '@scss/common' as *;
+
+.loading,
+.resourceBanner {
+  @include btnReset;
+  & {
+    width: 100%;
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    margin-bottom: 2rem;
+    border-radius: 2px;
+    background: var(--theme-success-100);
+    border: 1px solid var(--theme-success-200);
+    color: var(--theme-blue-text);
+  }
+}
+
+.loading {
+  background: linear-gradient(
+    90deg,
+    var(--theme-success-100) 25%,
+    var(--theme-success-150) 50%,
+    var(--theme-success-100) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1s infinite linear;
+  cursor: progress;
+
+  & > * {
+    width: 100%;
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: 100% 0;
+    }
+    100% {
+      background-position: -100% 0;
+    }
+  }
+}
+
+.resourceBanner {
+  cursor: pointer;
+  transition: opacity 0.1s ease-out;
+  &:hover {
+    opacity: 0.8;
+
+    .arrow {
+      transform: translateX(0.25rem);
+    }
+  }
+}
+
+.resourceTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  text-align: left;
+  @include body;
+
+  & {
+    font-weight: 500;
+  }
+}
+
+.skeleton,
+.drawerSkeleton {
+  display: block;
+  width: 100%;
+  height: 1lh;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    var(--theme-success-150) 25%,
+    var(--theme-success-200) 50%,
+    var(--theme-success-150) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1s infinite linear;
+}
+
+.drawerSkeleton {
+  height: 800px;
+  background: linear-gradient(
+    90deg,
+    var(--theme-elevation-150) 25%,
+    var(--theme-elevation-200) 50%,
+    var(--theme-elevation-150) 75%
+  );
+}
+
+.arrow {
+  transition: transform 0.1s ease-in-out;
+  transform: translateX(0);
+}
+
+.resourceContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 1080px;
+}
+
+.author {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.articleTitle {
+  margin: 0;
+}
+
+.resourceTypeBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  border-radius: 4px;
+  background-color: var(--theme-success-50);
+  color: var(--theme-success-800);
+  border: 1px solid var(--theme-success-200);
+  letter-spacing: normal;
+  font-weight: 400;
+  @include body;
+}

--- a/src/components/RichText/ResourceBlock/index.tsx
+++ b/src/components/RichText/ResourceBlock/index.tsx
@@ -28,6 +28,7 @@ export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
     if (!id) {
       return
     }
+    console.log({ id })
     const fetchResource = async () => {
       const query = qs.stringify({
         select: {

--- a/src/components/RichText/ResourceBlock/index.tsx
+++ b/src/components/RichText/ResourceBlock/index.tsx
@@ -28,7 +28,6 @@ export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
     if (!id) {
       return
     }
-    console.log({ id })
     const fetchResource = async () => {
       const query = qs.stringify({
         select: {
@@ -95,10 +94,6 @@ export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
     }
     await fetchResourceData()
   }, [resource, resourceData])
-
-  useEffect(() => {
-    console.log('Resource data:', resourceData)
-  }, [resourceData])
 
   return (
     <>

--- a/src/components/RichText/ResourceBlock/index.tsx
+++ b/src/components/RichText/ResourceBlock/index.tsx
@@ -171,6 +171,7 @@ export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
                       blockName: 'Related Posts',
                       blockType: 'relatedPosts',
                       relatedPosts: resourceData.relatedPosts || [],
+                      style: 'minimal',
                     },
                   ]}
                   disableGutter

--- a/src/components/RichText/ResourceBlock/index.tsx
+++ b/src/components/RichText/ResourceBlock/index.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import type { Post } from '@root/payload-types'
+
+import { Drawer, DrawerToggler } from '@components/Drawer'
+import { GuestSocials } from '@components/GuestSocials'
+import { Media } from '@components/Media'
+import { RenderBlocks } from '@components/RenderBlocks'
+import { Video } from '@components/RichText/Video/index'
+import { ArrowRightIcon } from '@icons/ArrowRightIcon'
+import { PlayIcon } from '@icons/PlayIcon'
+import { getVideo } from '@root/utilities/get-video'
+import { formatOxfordComma } from '@root/utilities/oxford-comma'
+import { qs } from '@root/utilities/qs'
+import { useCallback, useEffect, useState } from 'react'
+
+import classes from './index.module.scss'
+
+export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
+  const [resource, setResource] = useState<
+    | { category: string; featuredMedia: 'upload' | 'videoUrl'; slug: string; title: string }
+    | null
+    | undefined
+  >(null)
+  const [resourceData, setResourceData] = useState<null | Partial<Post> | undefined>(null)
+
+  useEffect(() => {
+    if (!id) {
+      return
+    }
+    const fetchResource = async () => {
+      const query = qs.stringify({
+        select: {
+          slug: true,
+          category: true,
+          featuredMedia: true,
+          title: true,
+        },
+      })
+      const res = await fetch(`/api/posts/${id}?${query}`)
+      const data = await res.json()
+
+      return data
+    }
+    fetchResource()
+      .then((res) =>
+        setResource({
+          slug: res.slug,
+          category: res.category.slug,
+          featuredMedia: res.featuredMedia,
+          title: res.title,
+        }),
+      )
+      .catch((err) => {
+        console.error('Error fetching resource:', err)
+        setResource(undefined)
+      })
+  }, [id])
+
+  const handleDrawerOpen = useCallback(async () => {
+    if (resourceData) {
+      return
+    }
+    const fetchResourceData = async () => {
+      const query = qs.stringify({
+        depth: 2,
+        select: {
+          authors: true,
+          authorType: true,
+          content: true,
+          excerpt: true,
+          guestAuthor: true,
+          guestSocials: true,
+          image: true,
+          publishedOn: true,
+          relatedResources: true,
+          videoUrl: true,
+        },
+        where: {
+          slug: {
+            equals: resource?.slug,
+          },
+        },
+      })
+
+      const res = await fetch(`/api/posts?${query}`)
+      const data = await res.json()
+
+      if (data?.docs?.length > 0) {
+        setResourceData(data.docs[0])
+      } else {
+        setResourceData(undefined)
+      }
+    }
+    await fetchResourceData()
+  }, [resource, resourceData])
+
+  useEffect(() => {
+    console.log('Resource data:', resourceData)
+  }, [resourceData])
+
+  return (
+    <>
+      <DrawerToggler
+        className={resource === null ? classes.loading : classes.resourceBanner}
+        disabled={!resource}
+        onClick={() => handleDrawerOpen()}
+        slug={`resource_${id}`}
+      >
+        {resource === null ? (
+          <span className={classes.skeleton} />
+        ) : resource === undefined ? (
+          <div>Linked resource not found</div>
+        ) : (
+          <>
+            <span className={classes.resourceTitle}>
+              {resource.featuredMedia === 'videoUrl' && <PlayIcon size="large" />}
+              {resource.category === 'guides' && 'Guide: '}
+              {resource.title}
+            </span>
+            <ArrowRightIcon className={classes.arrow} size="large" />
+          </>
+        )}
+      </DrawerToggler>
+      <Drawer
+        size="s"
+        slug={`resource_${id}`}
+        title={
+          resource?.category === 'guides' ? (
+            resourceData?.authorType === 'guest' ? (
+              <span className={classes.resourceTypeBadge}>Community Guide</span>
+            ) : (
+              <span className={classes.resourceTypeBadge}>Official Guide</span>
+            )
+          ) : (
+            <span className={classes.resourceTypeBadge}>Blog</span>
+          )
+        }
+      >
+        {resourceData ? (
+          <article className={classes.resourceContent}>
+            <h1 className={classes.articleTitle}>{resource?.title}</h1>
+            {resourceData && (
+              <span className={classes.author}>
+                By {resourceData?.authorType === 'guest' && resourceData.guestAuthor}
+                {resourceData?.authorType === 'team' &&
+                  formatOxfordComma(
+                    resourceData?.authors?.map(
+                      (author) =>
+                        typeof author !== 'string' && `${author.firstName} ${author.lastName}`,
+                    ),
+                  )}
+                {resourceData?.authorType === 'guest' && resourceData?.guestSocials && (
+                  <GuestSocials guestSocials={resourceData?.guestSocials} />
+                )}
+              </span>
+            )}
+            {resourceData?.featuredMedia === 'upload'
+              ? resourceData?.image &&
+                typeof resourceData?.image !== 'string' && (
+                  <Media className={classes.heroImage} priority resource={resourceData?.image} />
+                )
+              : resourceData?.videoUrl && <Video {...getVideo(resourceData?.videoUrl)} />}
+            {resourceData?.content && <RenderBlocks blocks={resourceData.content} disableGutter />}
+            {resourceData?.relatedPosts &&
+              typeof resourceData.relatedPosts[0] !== 'string' &&
+              typeof resourceData.relatedPosts[0]?.image !== 'string' && (
+                <RenderBlocks
+                  blocks={[
+                    {
+                      blockName: 'Related Posts',
+                      blockType: 'relatedPosts',
+                      relatedPosts: resourceData.relatedPosts || [],
+                    },
+                  ]}
+                  disableGutter
+                />
+              )}
+          </article>
+        ) : (
+          <div className={classes.drawerSkeleton} />
+        )}
+      </Drawer>
+    </>
+  )
+}

--- a/src/components/RichText/ResourceBlock/index.tsx
+++ b/src/components/RichText/ResourceBlock/index.tsx
@@ -155,7 +155,7 @@ export const ResourceBlock: React.FC<{ id: string }> = ({ id }) => {
                 )}
               </span>
             )}
-            {resourceData?.featuredMedia === 'upload'
+            {resource?.featuredMedia === 'upload'
               ? resourceData?.image &&
                 typeof resourceData?.image !== 'string' && (
                   <Media className={classes.heroImage} priority resource={resourceData?.image} />

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -125,7 +125,15 @@ export const jsxConverters: (args: { toc?: boolean }) => JSXConvertersFunction<N
           )
         },
         Resource: ({ node }) => {
-          return <Resource {...node.fields} />
+          if (!node.fields.post) {
+            return null
+          }
+
+          if (typeof node.fields.post === 'string') {
+            return <Resource id={node.fields.post} />
+          } else {
+            return <Resource id={node.fields.post.id} />
+          }
         },
         RestExamples: ({ node }) => {
           return <RestExamples data={node.fields.data} />

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -13,6 +13,7 @@ import type {
   Doc,
   DownloadBlockType,
   LightDarkImageBlock,
+  ResourceBlock,
   RestExamplesBlock,
   SpotlightBlock,
   TableWithDrawersBlock,
@@ -43,6 +44,7 @@ import {
   type JSXConvertersFunction,
   RichText as SerializedRichText,
 } from '@payloadcms/richtext-lexical/react'
+import { Download } from '@root/components/blocks/Download'
 import { getVideo } from '@root/utilities/get-video'
 import React, { useCallback, useState } from 'react'
 
@@ -51,12 +53,12 @@ import type { AllowedElements } from '../SpotlightAnimation/types'
 import { type AddHeading, type Heading, type IContext, RichTextContext } from './context'
 import { Heading as HeadingComponent } from './Heading'
 import LightDarkImage from './LightDarkImage/index'
+import { ResourceBlock as Resource } from './ResourceBlock'
 import { RestExamples } from './RestExamples'
 import { CustomTableJSXConverters } from './Table/index'
 import { TableWithDrawers } from './TableWithDrawers'
 import { UploadBlockImage } from './UploadBlock/index'
 import { VideoDrawer } from './VideoDrawer'
-import { Download } from '@root/components/blocks/Download'
 
 type Props = {
   className?: string
@@ -72,6 +74,7 @@ export type NodeTypes =
       | CommandLineBlock
       | DownloadBlockType
       | LightDarkImageBlock
+      | ResourceBlock
       | RestExamplesBlock
       | SpotlightBlock
       | TableWithDrawersBlock
@@ -120,6 +123,9 @@ export const jsxConverters: (args: { toc?: boolean }) => JSXConvertersFunction<N
               srcLight={node.fields.srcLight}
             />
           )
+        },
+        Resource: ({ node }) => {
+          return <Resource {...node.fields} />
         },
         RestExamples: ({ node }) => {
           return <RestExamples data={node.fields.data} />
@@ -246,13 +252,13 @@ export const RichTextWithTOC: React.FC<Props> = ({ className, content: _content 
   }
 
   return (
-    <RichTextContext.Provider value={context}>
+    <RichTextContext value={context}>
       <SerializedRichText
         className={['payload-richtext', 'docs-richtext', className].filter(Boolean).join(' ')}
         converters={jsxConverters({ toc: true })}
         data={content}
       />
-    </RichTextContext.Provider>
+    </RichTextContext>
   )
 }
 

--- a/src/components/blocks/RelatedPosts/index.module.scss
+++ b/src/components/blocks/RelatedPosts/index.module.scss
@@ -9,3 +9,9 @@
   display: grid;
   row-gap: 2rem;
 }
+
+.minimal {
+  .grid {
+    row-gap: 1rem;
+  }
+}

--- a/src/components/blocks/RelatedPosts/index.tsx
+++ b/src/components/blocks/RelatedPosts/index.tsx
@@ -11,10 +11,11 @@ export type RelatedPostsBlock = {
   disableGutter?: boolean
   id?: string
   relatedPosts: (Post | string)[] | null
+  style?: 'default' | 'minimal'
 }
 
 export const RelatedPosts: React.FC<RelatedPostsBlock> = (props) => {
-  const { id = '', disableGutter, relatedPosts } = props
+  const { id = '', disableGutter, relatedPosts, style } = props
 
   if (!relatedPosts || relatedPosts?.length === 0) {
     return null
@@ -22,7 +23,10 @@ export const RelatedPosts: React.FC<RelatedPostsBlock> = (props) => {
 
   return (
     <Gutter leftGutter={!disableGutter} rightGutter={!disableGutter}>
-      <div className={classes.relatedPosts} id={id}>
+      <div
+        className={[classes.relatedPosts, style && classes[style]].filter(Boolean).join(' ')}
+        id={id}
+      >
         <h4 className={classes.title}>Related Posts</h4>
         <div className={classes.grid}>
           {relatedPosts
@@ -42,10 +46,11 @@ export const RelatedPosts: React.FC<RelatedPostsBlock> = (props) => {
                 typeof post !== 'string' && (
                   <div className={['cols-8 cols-m-8'].filter(Boolean).join(' ')} key={post.id}>
                     <ContentMediaCard
-                      authors={post.authors}
+                      authors={post.authorType === 'team' ? post.authors : post.guestAuthor}
                       href={`/posts/${postCategory}/${post.slug}`}
                       media={thumbnailAsset ?? ''}
                       publishedOn={post.publishedOn}
+                      style={style}
                       title={post.title}
                     />
                   </div>

--- a/src/components/cards/ContentMediaCard/index.module.scss
+++ b/src/components/cards/ContentMediaCard/index.module.scss
@@ -64,7 +64,6 @@
     max-width: 100%;
   }
 }
-
 .meta {
   display: flex;
   flex-wrap: wrap;
@@ -108,5 +107,24 @@
   @include small-break {
     width: 100%;
     padding: 0;
+  }
+}
+
+.minimal {
+  border: 1px solid var(--theme-border-color);
+  .media {
+    max-width: 25%;
+  }
+
+  .title {
+    margin-bottom: 0;
+    @include body;
+    & {
+      font-weight: 500;
+    }
+  }
+
+  .scanline {
+    border: none;
   }
 }

--- a/src/components/cards/ContentMediaCard/index.tsx
+++ b/src/components/cards/ContentMediaCard/index.tsx
@@ -10,17 +10,22 @@ import type { ContentMediaCardProps } from '../types'
 import classes from './index.module.scss'
 
 export const ContentMediaCard: React.FC<ContentMediaCardProps> = (props) => {
-  const { authors, className, href, media, publishedOn, title } = props
+  const { authors, className, href, media, publishedOn, style, title } = props
 
-  const author = authors?.[0]
-    ? typeof authors?.[0] === 'string'
-      ? authors[0]
-      : authors[0].firstName + ' ' + authors[0].lastName
-    : null
+  const author =
+    typeof authors === 'string'
+      ? authors
+      : authors?.[0]
+        ? typeof authors?.[0] === 'string'
+          ? authors[0]
+          : authors[0].firstName + ' ' + authors[0].lastName
+        : null
 
   return (
     <Link
-      className={[classes.blogCard, className && className].filter(Boolean).join(' ')}
+      className={[classes.blogCard, style && classes[style], className && className]
+        .filter(Boolean)
+        .join(' ')}
       href={href}
       prefetch={false}
     >

--- a/src/components/cards/types.ts
+++ b/src/components/cards/types.ts
@@ -16,11 +16,12 @@ export interface SquareCardProps extends SharedProps {
 }
 
 export interface ContentMediaCardProps extends SharedProps {
-  authors: Post['authors']
+  authors: Post['authors'] | Post['guestAuthor']
   href: string
   media: Media | string
   orientation?: 'horizontal' | 'vertical'
   publishedOn?: string
+  style?: 'default' | 'minimal'
 }
 
 export interface PricingCardProps extends SharedProps {

--- a/src/fields/addToDocs/Label.tsx
+++ b/src/fields/addToDocs/Label.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import type { TextFieldClientComponent } from 'payload'
+
+import { CopyToClipboard, useField } from '@payloadcms/ui'
+
+import classes from './index.module.scss'
+
+export const Label: TextFieldClientComponent = ({ path }) => {
+  const { value } = useField({ path })
+  return (
+    <span className={classes.label}>
+      Add to Docs <CopyToClipboard value={value as string} />
+    </span>
+  )
+}

--- a/src/fields/addToDocs/index.module.scss
+++ b/src/fields/addToDocs/index.module.scss
@@ -1,0 +1,6 @@
+.label {
+  margin-bottom: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}

--- a/src/fields/addToDocs/index.ts
+++ b/src/fields/addToDocs/index.ts
@@ -1,0 +1,20 @@
+import type { Field } from 'payload'
+
+export const addToDocs: Field = {
+  name: 'addToDocs',
+  type: 'text',
+  admin: {
+    components: {
+      Label: '@root/fields/addToDocs/Label#Label',
+    },
+    description: 'Paste this code into the docs to link to this post',
+    position: 'sidebar',
+  },
+  hooks: {
+    beforeChange: [
+      ({ originalDoc }) => {
+        return `<Resource id="${originalDoc?.id}" />`
+      },
+    ],
+  },
+}

--- a/src/icons/PlayIcon/index.tsx
+++ b/src/icons/PlayIcon/index.tsx
@@ -22,11 +22,22 @@ export const PlayIcon: React.FC<IconProps> = (props) => {
       style={{
         transform: rotation ? `rotate(${rotation}deg)` : undefined,
       }}
-      viewBox="0 0 23 25"
+      viewBox="0 0 20 20"
       width="100%"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path d="M0.470703 25V0L22.5293 12.8676L0.470703 25Z" fill="white" fillOpacity="0.75" />
+      <path
+        className={classes.stroke}
+        d="M17.3889 0.5H2.61111C1.44518 0.5 0.5 1.44518 0.5 2.61111V17.3889C0.5 18.5548 1.44518 19.5 2.61111 19.5H17.3889C18.5548 19.5 19.5 18.5548 19.5 17.3889V2.61111C19.5 1.44518 18.5548 0.5 17.3889 0.5Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        className={classes.stroke}
+        d="M6.83333 5.77778L13.1667 10L6.83333 14.2222V5.77778Z"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   )
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -3056,6 +3056,7 @@ export interface RestExamplesBlock {
  * via the `definition` "ResourceBlock".
  */
 export interface ResourceBlock {
+  post?: (string | null) | Post;
   id?: string | null;
   blockName?: string | null;
   blockType: 'Resource';

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -845,6 +845,10 @@ export interface Post {
     website?: string | null;
   };
   publishedOn: string;
+  /**
+   * Paste this code into the docs to link to this post
+   */
+  addToDocs?: string | null;
   meta?: {
     title?: string | null;
     description?: string | null;
@@ -3654,6 +3658,7 @@ export interface PostsSelect<T extends boolean = true> {
         website?: T;
       };
   publishedOn?: T;
+  addToDocs?: T;
   meta?:
     | T
     | {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -96,6 +96,7 @@ export interface Config {
     RestExamples: RestExamplesBlock;
     pricing: Pricing;
     reusableContentBlock: ReusableContentBlock;
+    Resource: ResourceBlock;
     slider: Slider;
     statement: Statement;
     steps: StepsBlock;
@@ -3045,6 +3046,15 @@ export interface RestExamplesBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'RestExamples';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ResourceBlock".
+ */
+export interface ResourceBlock {
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'Resource';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -57,6 +57,7 @@ import { Docs } from './collections/Docs'
 import { BannerBlock } from './collections/Docs/blocks/banner'
 import { CodeBlock } from './collections/Docs/blocks/code'
 import { LightDarkImageBlock } from './collections/Docs/blocks/lightDarkImage'
+import { ResourceBlock } from './collections/Docs/blocks/resource'
 import { RestExamplesBlock } from './collections/Docs/blocks/restExamples'
 import { TableWithDrawersBlock } from './collections/Docs/blocks/tableWithDrawers'
 import { UploadBlock } from './collections/Docs/blocks/upload'
@@ -132,6 +133,7 @@ export default buildConfig({
     RestExamplesBlock,
     Pricing,
     ReusableContentBlock,
+    ResourceBlock,
     Slider,
     Statement,
     Steps,

--- a/src/utilities/oxford-comma.ts
+++ b/src/utilities/oxford-comma.ts
@@ -1,0 +1,2 @@
+export const formatOxfordComma = (items) =>
+  items.length < 3 ? items.join(' and ') : `${items.slice(0, -1).join(', ')}, and ${items.at(-1)}`


### PR DESCRIPTION
Adds a new `Resource` block for linking useful posts and guides in the documentation.

**Example:**

```
<Resource id=" post id goes here " />
```
---
![Screenshot 2025-04-04 at 3 04 53 PM](https://github.com/user-attachments/assets/14b631e3-cd1c-4129-846f-e83b21a21aef)
