### PR TITLE
Feat / Refactor - Utility function to return object literals as sizes for Next.js Image Component

### DIFF
--- a/cssVariables.cjs
+++ b/cssVariables.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  breakpoints: {
-    s: 768,
-    m: 1024,
-    l: 1440,
-  },
-}

--- a/src/components/Media/Image/index.tsx
+++ b/src/components/Media/Image/index.tsx
@@ -1,18 +1,15 @@
 'use client'
 
+import type { MediaProps } from '@components/Media/types'
 import type { StaticImageData } from 'next/image'
 
+import { standardSizes } from '@utilities/image-sizes'
 import NextImage from 'next/image'
-import React, { useState } from 'react'
+import React from 'react'
 
-import type { Props } from '../types'
-
-import cssVariables from '../../../../cssVariables.cjs'
 import classes from './index.module.scss'
 
-const { breakpoints } = cssVariables
-
-export const Image: React.FC<Props> = (props) => {
+export const Image: React.FC<MediaProps> = (props) => {
   const {
     alt: altFromProps,
     fill,
@@ -27,12 +24,13 @@ export const Image: React.FC<Props> = (props) => {
     width: widthFromProps,
   } = props
 
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = React.useState(true)
 
   let width: null | number | undefined = widthFromProps
   let height: null | number | undefined = heightFromProps
   let alt = altFromProps
   let src: null | StaticImageData | string | undefined = srcFromProps
+  const sizes = sizesFromProps || standardSizes
 
   const hasDarkModeFallback =
     resource?.darkModeFallback &&
@@ -46,13 +44,6 @@ export const Image: React.FC<Props> = (props) => {
     alt = resource.alt
     src = resource.url
   }
-
-  // NOTE: this is used by the browser to determine which image to download at different screen sizes
-  const sizes =
-    sizesFromProps ||
-    Object.entries(breakpoints)
-      .map(([, value]) => `(max-width: ${value}px) ${value}px`)
-      .join(', ')
 
   const baseClasses = [
     isLoading && classes.placeholder,

--- a/src/components/Media/types.ts
+++ b/src/components/Media/types.ts
@@ -2,7 +2,7 @@ import type { StaticImageData } from 'next/image'
 import type { TypedUploadCollection, UploadCollectionSlug } from 'payload'
 import type { ElementType, Ref } from 'react'
 
-export interface Props {
+export interface MediaProps {
   alt?: string
   className?: string
   fill?: boolean // for NextImage only

--- a/src/utilities/image-sizes.ts
+++ b/src/utilities/image-sizes.ts
@@ -1,0 +1,26 @@
+/* eslint-disable */
+/* perfectionist/sort-objects complaining about order of breakpoints */
+
+/**
+ * Formats object literals into strings that conform
+ * to Next.js's `sizes` prop for the Image component.
+ * 
+ * The utility function `stringifyBreakpoints({size: number})` 
+ * can be imported to create custom breakpoints for specific
+ * `Image` components if needed.
+ * 
+ */
+
+type Breakpoint = {
+  [size: string]: number
+}
+
+export const stringifyBreakpoints = <B extends Breakpoint>(
+  breakpoints: B
+): string => {
+  return Object.entries(breakpoints)
+    .map(([, width]) => `(max-width: ${width}px) ${width}px`)
+    .join(', ')
+}
+
+export const standardSizes = stringifyBreakpoints({s: 768, m: 1024, l: 1440})


### PR DESCRIPTION
This pull request refactors how responsive image breakpoints are handled for the `Image` component, improving code organization and maintainability. The main change is moving breakpoint logic out of a shared config file and into a dedicated utility, and updating the component to use this utility. Type definitions are also updated for clarity.

**Image component refactor and responsive breakpoints:**

* Removed `breakpoints` from the shared `cssVariables.cjs` config file, centralizing breakpoint logic in a new utility.
* Added a new utility file `src/utilities/image-sizes.ts` that provides a `stringifyBreakpoints` function and a `standardSizes` constant for generating responsive image `sizes` strings.
* Updated the `Image` component (`src/components/Media/Image/index.tsx`) to use `standardSizes` from the new utility instead of importing breakpoints from `cssVariables.cjs`. [[1]](diffhunk://#diff-72af9358a692e411515ad10792a968af6cdbb4f9f16c8c0728789f9c66993f64R3-R12) [[2]](diffhunk://#diff-72af9358a692e411515ad10792a968af6cdbb4f9f16c8c0728789f9c66993f64L30-R33) [[3]](diffhunk://#diff-72af9358a692e411515ad10792a968af6cdbb4f9f16c8c0728789f9c66993f64L50-L56)

**Type definition updates:**

* Renamed the image component props interface from `Props` to `MediaProps` in `src/components/Media/types.ts` for consistency and clarity.