### PR TITLE
fix: increase pages limit for fetchPage in case multile pages has the same slug

### DIFF
--- a/src/app/_data/index.ts
+++ b/src/app/_data/index.ts
@@ -54,6 +54,8 @@ export const fetchPage = async (incomingSlugSegments: string[]): Promise<null | 
   const slugSegments = incomingSlugSegments || ['home']
   const slug = slugSegments.at(-1)
 
+  const pagePath = `/${slugSegments.join('/')}`
+
   const data = await payload.find({
     collection: 'pages',
     depth: 2,
@@ -64,6 +66,11 @@ export const fetchPage = async (incomingSlugSegments: string[]): Promise<null | 
         {
           slug: {
             equals: slug,
+          },
+        },
+        {
+          breadcrumbs__url: {
+            equals: pagePath,
           },
         },
         ...(draft
@@ -78,8 +85,6 @@ export const fetchPage = async (incomingSlugSegments: string[]): Promise<null | 
       ],
     },
   })
-
-  const pagePath = `/${slugSegments.join('/')}`
 
   const page = data.docs.find(({ breadcrumbs }: Page) => {
     if (!breadcrumbs) {


### PR DESCRIPTION
This PR fixes the use case when there are multiple pages with the same slug
For example:
 - bar
 - foo/bar
 
 Right now, the limit is 1. So an array with only one page with the slug `bar` is returned leading 404 page for other page. 
 
 Solution: increasing the limit to 10000.
 
 Additional filter 
 
 ```
 {
          breadcrumbs__url: {
            equals: pagePath,
          },
        },
  ```
  
 is added for optimization. Using this approach /bar page isn't returned for /foo/bar.