### PR TITLE
fix(deps): bump next to 15.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "graphql": "16.8.1",
     "gray-matter": "^4.0.3",
     "instantsearch.js": "^4.72.2",
-    "next": "15.4.8",
+    "next": "15.4.9",
     "next-sitemap": "^4.0.6",
     "node-cron": "^3.0.3",
     "nodemailer-sendgrid": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,10 +43,10 @@ importers:
         version: 3.43.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@payloadcms/next':
         specifier: 3.43.0
-        version: 3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+        version: 3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@payloadcms/plugin-form-builder':
         specifier: 3.43.0
-        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@payloadcms/plugin-nested-docs':
         specifier: 3.43.0
         version: 3.43.0(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))
@@ -55,16 +55,16 @@ importers:
         version: 3.43.0(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))
       '@payloadcms/plugin-seo':
         specifier: 3.43.0
-        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@payloadcms/richtext-lexical':
         specifier: 3.43.0
-        version: 3.43.0(@faceless-ui/modal@3.0.0-beta.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3))(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)(yjs@13.6.24)
+        version: 3.43.0(@faceless-ui/modal@3.0.0-beta.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3))(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)(yjs@13.6.24)
       '@payloadcms/storage-vercel-blob':
         specifier: 3.43.0
-        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@payloadcms/ui':
         specifier: 3.43.0
-        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+        version: 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -100,7 +100,7 @@ importers:
         version: 12.0.0-alpha.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       geist:
         specifier: ^1.3.1
-        version: 1.3.1(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))
+        version: 1.3.1(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -111,11 +111,11 @@ importers:
         specifier: ^4.72.2
         version: 4.78.0(algoliasearch@4.24.0)
       next:
-        specifier: 15.4.8
-        version: 15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
+        specifier: 15.4.9
+        version: 15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
       next-sitemap:
         specifier: ^4.0.6
-        version: 4.2.3(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))
+        version: 4.2.3(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))
       node-cron:
         specifier: ^3.0.3
         version: 3.0.3
@@ -1071,8 +1071,8 @@ packages:
   '@next/env@15.3.3':
     resolution: {integrity: sha512-OdiMrzCl2Xi0VTjiQQUK0Xh7bJHnOuET2s+3V+Y40WJBAXrJeGA3f+I8MZJ/YQ3mVGi5XGR1L66oFlgqXhQ4Vw==}
 
-  '@next/env@15.4.8':
-    resolution: {integrity: sha512-LydLa2MDI1NMrOFSkO54mTc8iIHSttj6R6dthITky9ylXV2gCGi0bHQjVCtLGRshdRPjyh2kXbxJukDtBWQZtQ==}
+  '@next/env@15.4.9':
+    resolution: {integrity: sha512-OYR0RulK5phnbxxzcLE4/ECgfx1PL3EHrDbjyelJ7jauaO+/Qvj5gG8JPMltB51CygC2KrZ0aAfYLjPYjYY17A==}
 
   '@next/swc-darwin-arm64@15.4.8':
     resolution: {integrity: sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==}
@@ -3457,8 +3457,8 @@ packages:
     peerDependencies:
       next: '*'
 
-  next@15.4.8:
-    resolution: {integrity: sha512-jwOXTz/bo0Pvlf20FSb6VXVeWRssA2vbvq9SdrOPEg9x8E1B27C2rQtvriAn600o9hH61kjrVRexEffv3JybuA==}
+  next@15.4.9:
+    resolution: {integrity: sha512-/NedNmbiH4Umt/7SohT9VKxEdBt02Lj33xHrukE7d8Li6juT+75sEq4a4U06jggrvdbklKgr78OZEyWZ8XRrtw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -5513,7 +5513,7 @@ snapshots:
 
   '@next/env@15.3.3': {}
 
-  '@next/env@15.4.8': {}
+  '@next/env@15.4.9': {}
 
   '@next/swc-darwin-arm64@15.4.8':
     optional: true
@@ -5720,12 +5720,12 @@ snapshots:
 
   '@payloadcms/live-preview@3.43.0': {}
 
-  '@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
       '@dnd-kit/core': 6.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@payloadcms/graphql': 3.43.0(graphql@16.8.1)(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(typescript@5.7.3)
       '@payloadcms/translations': 3.43.0
-      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       busboy: 1.6.0
       dequal: 2.0.3
       file-type: 19.3.0
@@ -5733,7 +5733,7 @@ snapshots:
       graphql-http: 1.22.4(graphql@16.8.1)
       graphql-playground-html: 1.6.30
       http-status: 2.1.0
-      next: 15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
+      next: 15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
       path-to-regexp: 6.3.0
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
       qs-esm: 7.0.2
@@ -5747,9 +5747,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/plugin-cloud-storage@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/plugin-cloud-storage@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
-      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       find-node-modules: 2.1.3
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
       range-parser: 1.2.1
@@ -5762,9 +5762,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/plugin-form-builder@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/plugin-form-builder@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
-      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       escape-html: 1.0.3
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
       react: 19.2.1
@@ -5784,10 +5784,10 @@ snapshots:
     dependencies:
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
 
-  '@payloadcms/plugin-seo@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/plugin-seo@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
       '@payloadcms/translations': 3.43.0
-      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -5798,7 +5798,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@payloadcms/richtext-lexical@3.43.0(@faceless-ui/modal@3.0.0-beta.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3))(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)(yjs@13.6.24)':
+  '@payloadcms/richtext-lexical@3.43.0(@faceless-ui/modal@3.0.0-beta.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@faceless-ui/scroll-info@2.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(@payloadcms/next@3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3))(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)(yjs@13.6.24)':
     dependencies:
       '@faceless-ui/modal': 3.0.0-beta.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@faceless-ui/scroll-info': 2.0.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -5812,9 +5812,9 @@ snapshots:
       '@lexical/selection': 0.28.0
       '@lexical/table': 0.28.0
       '@lexical/utils': 0.28.0
-      '@payloadcms/next': 3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/next': 3.43.0(@types/react@19.1.8)(graphql@16.8.1)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@payloadcms/translations': 3.43.0
-      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/ui': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@types/uuid': 10.0.0
       acorn: 8.12.1
       bson-objectid: 2.0.4
@@ -5841,9 +5841,9 @@ snapshots:
       - typescript
       - yjs
 
-  '@payloadcms/storage-vercel-blob@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/storage-vercel-blob@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
-      '@payloadcms/plugin-cloud-storage': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
+      '@payloadcms/plugin-cloud-storage': 3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)
       '@vercel/blob': 0.22.3
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
     transitivePeerDependencies:
@@ -5859,7 +5859,7 @@ snapshots:
     dependencies:
       date-fns: 4.1.0
 
-  '@payloadcms/ui@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
+  '@payloadcms/ui@3.43.0(@types/react@19.1.8)(monaco-editor@0.52.2)(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0))(payload@3.43.0(graphql@16.8.1)(typescript@5.7.3))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.7.3)':
     dependencies:
       '@date-fns/tz': 1.2.0
       '@dnd-kit/core': 6.0.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -5874,7 +5874,7 @@ snapshots:
       date-fns: 4.1.0
       dequal: 2.0.3
       md5: 2.3.0
-      next: 15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
+      next: 15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
       object-to-formdata: 4.5.1
       payload: 3.43.0(graphql@16.8.1)(typescript@5.7.3)
       qs-esm: 7.0.2
@@ -7441,9 +7441,9 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  geist@1.3.1(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)):
+  geist@1.3.1(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)):
     dependencies:
-      next: 15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
+      next: 15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -8451,17 +8451,17 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-sitemap@4.2.3(next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)):
+  next-sitemap@4.2.3(next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.8
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
+      next: 15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0)
 
-  next@15.4.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0):
+  next@15.4.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.86.0):
     dependencies:
-      '@next/env': 15.4.8
+      '@next/env': 15.4.9
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001706
       postcss: 8.4.31


### PR DESCRIPTION
Addresses [CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184) and [CVE-2025-55183](https://www.cve.org/CVERecord?id=CVE-2025-55183).

More details here: https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183#how-to-upgrade-and-protect-your-next.js-app