### PR TITLE
feat(docs): pin v3 docs to 3.x branch

### DIFF
--- a/src/collections/Docs/BranchButton/index.tsx
+++ b/src/collections/Docs/BranchButton/index.tsx
@@ -3,6 +3,7 @@ import type { CustomComponent, PayloadServerReactComponent } from 'payload'
 import { ShimmerEffect } from '@payloadcms/ui'
 import React from 'react'
 
+import { branchForVersion } from '../branchForVersion'
 import { fetchAllBranches } from './fetchAllBranches'
 import { BranchButtonClient } from './index.client'
 
@@ -35,11 +36,7 @@ export const BranchButtonPromise: PayloadServerReactComponent<CustomComponent> =
 
   let branch: null | string = (branchQueryParam as string) ?? null
   if (!branch) {
-    if (doc.version === 'v3') {
-      branch = 'main'
-    } else if (doc.version === 'v2') {
-      branch = '2.x'
-    }
+    branch = branchForVersion(doc.version)
   }
 
   return <BranchButtonClient branch={branch} branchNames={branchNames} />

--- a/src/collections/Docs/SaveButton/index.tsx
+++ b/src/collections/Docs/SaveButton/index.tsx
@@ -19,6 +19,8 @@ import { useSearchParams } from 'next/navigation'
 import * as qs from 'qs-esm'
 import React, { useRef } from 'react'
 
+import { branchForVersion } from '../branchForVersion'
+
 import './index.scss'
 
 export const SaveButtonClient: React.FC<SaveButtonClientProps> = (props) => {
@@ -48,7 +50,7 @@ export const SaveButtonClient: React.FC<SaveButtonClientProps> = (props) => {
   const action: string = React.useMemo(() => {
     const docURL = `${baseURL}/${collectionSlug}${id ? `/${id}` : ''}`
     const params = {
-      branch: searchParams.get('branch') ?? (versionField?.value === 'v2' ? '2.x' : 'main'),
+      branch: searchParams.get('branch') ?? branchForVersion(versionField?.value),
       commit: true,
       depth: 0,
       'fallback-locale': 'null',

--- a/src/collections/Docs/branchForVersion.ts
+++ b/src/collections/Docs/branchForVersion.ts
@@ -1,0 +1,20 @@
+const versionToBranch = {
+  v2: '2.x',
+  v3: '3.x',
+} as const
+
+export type DocVersion = keyof typeof versionToBranch
+export type DocBranch = (typeof versionToBranch)[DocVersion]
+
+export function branchForVersion(version: unknown): DocBranch {
+  if (typeof version === 'string' && version in versionToBranch) {
+    return versionToBranch[version as DocVersion]
+  }
+  return versionToBranch.v3
+}
+
+const defaultBranches: readonly string[] = Object.values(versionToBranch)
+
+export function isDefaultBranch(branch: unknown): boolean {
+  return typeof branch === 'string' && defaultBranches.includes(branch)
+}

--- a/src/collections/Docs/index.ts
+++ b/src/collections/Docs/index.ts
@@ -17,6 +17,7 @@ import { topicGroupsToDocsData } from '@root/scripts/syncDocs'
 import { revalidatePath } from 'next/cache'
 
 import { isAdmin } from '../../access/isAdmin'
+import { branchForVersion, isDefaultBranch } from './branchForVersion'
 import { lexicalToMDX } from './mdxToLexical'
 
 export const contentLexicalEditorFeatures: FeatureProviderServer[] = [
@@ -227,7 +228,8 @@ export const Docs: CollectionConfig = {
         }
         const queryParams = req.query
 
-        if (!req.query.branch || req.query.branch === 'main' || req.query.branch === '2.x') {
+        const queryBranch = req.query.branch as string | undefined
+        if (!queryBranch || isDefaultBranch(queryBranch)) {
           return doc // No special branch - no need to request special data
         }
 
@@ -239,7 +241,7 @@ export const Docs: CollectionConfig = {
         const version: string = doc?.version === 'v2' ? 'v2' : 'v3'
 
         if (!branch) {
-          branch = version === 'v2' ? '2.x' : 'main'
+          branch = branchForVersion(version)
         }
 
         const topicGroup = await fetchSingleDoc({
@@ -299,7 +301,7 @@ export const Docs: CollectionConfig = {
             let branch: string = req.query.branch as string
 
             if (!branch) {
-              branch = _doc?.version === 'v2' ? '2.x' : 'main'
+              branch = branchForVersion(_doc?.version)
             }
 
             const response = await fetch(process.env.COMMIT_DOCS_API_URL, {
@@ -319,7 +321,7 @@ export const Docs: CollectionConfig = {
               throw new Error(`Failed to commit docs: ${response.statusText}`)
             }
 
-            if (branch !== '2.x' && branch !== 'main') {
+            if (!isDefaultBranch(branch)) {
               return originalDoc
             }
           }

--- a/src/components/Feedback/index.tsx
+++ b/src/components/Feedback/index.tsx
@@ -10,7 +10,7 @@ import React from 'react'
 import classes from './index.module.scss'
 export const Feedback: React.FC<{ path: string; ref?: string }> = async ({
   path,
-  ref = 'main',
+  ref = '3.x',
 }) => {
   const drawerSlug = 'feedbackDrawer'
   const formName = 'Feedback'

--- a/src/scripts/fetchDocs.ts
+++ b/src/scripts/fetchDocs.ts
@@ -20,7 +20,7 @@ const headers = {
   Authorization: `token ${process.env.GITHUB_ACCESS_TOKEN}`,
 }
 
-let ref: ('2.x' | 'main') | ({} & string)
+let ref: ('2.x' | '3.x') | ({} & string)
 let source: 'github' | 'local' = 'local'
 let version: ('v2' | 'v3') | ({} & string) = 'v3'
 
@@ -130,7 +130,7 @@ export async function fetchDocs(args?: {
   source?: typeof source
   version?: typeof version
 }): Promise<TopicGroup[]> {
-  ref = args?.ref ?? 'main'
+  ref = args?.ref ?? '3.x'
   source = args?.source ?? 'github'
   version = args?.version ?? 'v3'
 
@@ -201,7 +201,7 @@ export async function fetchSingleDoc(args: {
   topicSlug: string
   version?: typeof version
 }): Promise<null | TopicGroup> {
-  ref = args?.ref ?? 'main'
+  ref = args?.ref ?? '3.x'
   source = args?.source ?? 'github'
   version = args?.version ?? 'v3'
 

--- a/src/scripts/generateLLMs.ts
+++ b/src/scripts/generateLLMs.ts
@@ -11,7 +11,7 @@ async function generateLLMs() {
     return
   }
 
-  const output = await fetchDocs({ ref: 'main', version: 'v3' })
+  const output = await fetchDocs({ ref: '3.x', version: 'v3' })
 
   let outputStr = '# Payload\n\n'
   let fullOutputStr = `# Payload Documentation\n\n`

--- a/src/scripts/syncDocs.ts
+++ b/src/scripts/syncDocs.ts
@@ -118,7 +118,7 @@ export const syncDocs: PayloadHandler = async (req) => {
       return new Response('No GitHub access token found', { status: 400 })
     }
     try {
-      const allV3Docs = await fetchDocs({ ref: 'main', version: 'v3' })
+      const allV3Docs = await fetchDocs({ ref: '3.x', version: 'v3' })
       const allV2Docs = await fetchDocs({ ref: '2.x', version: 'v2' })
 
       const createdOrUpdatedDocs: string[] = []


### PR DESCRIPTION
# Overview

The `payloadcms/payload` `main` branch is about to flip to v4-beta content. This PR repoints every v3 docs code path at the `3.x` branch so v3 documentation keeps serving the correct content after the flip. No beta route or new version is introduced yet; that is deferred.

## Key Changes

- **New `branchForVersion` helper**
  - `src/collections/Docs/branchForVersion.ts` owns the version→branch mapping (`v2` → `2.x`, `v3` → `3.x`). `DocVersion` and `DocBranch` derive from the map via `keyof typeof` + indexed access.
  - Exposes `branchForVersion(version: unknown)` (narrows internally, defaults to `v3`) and `isDefaultBranch(branch: unknown)`.

- **Admin wiring routes through the helper**
  - `Docs` collection `afterRead` / `beforeChange` hooks, `BranchButton`, and `SaveButton` all resolve the branch via `branchForVersion` instead of inline ternaries.
  - The `afterRead` guard that short-circuits when the request targets the canonical branch now uses `isDefaultBranch`.

- **Scripts repointed at `3.x`**
  - `fetchDocs.ts` default ref, `syncDocs.ts` v3 sync source, and `generateLLMs.ts` all switch `'main'` → `'3.x'`. Scripts keep their literal branch args alongside the existing `version` field.

- **Feedback "Edit on GitHub" link**
  - Default `ref` in `components/Feedback` moves from `'main'` to `'3.x'` so the GitHub edit link lands on the correct branch.

## Design Decisions

- **Helper takes `unknown`, not a narrow union.** Upstream values (`doc.version`, `versionField?.value`, query params) are untyped at the call site. Accepting `unknown` and narrowing inside keeps `as` casts out of call sites and matches the shape of `isDefaultBranch`. Adding v4-beta later is a one-line edit to the mapping.
- **Scripts intentionally keep literal branch refs.** Each script already carries a matching `version` arg; routing through the helper would not remove duplication today. Revisit when more versions exist and iteration over `Object.entries(versionToBranch)` becomes worthwhile.
- **Cloud/styleguide `'main'` literals left alone.** Those refer to user repositories and placeholder data, not the Payload docs repo.
- **No new beta route, no topicOrder changes, no VersionSelector changes.** Scope is limited to preventing v3 from silently serving v4-beta content.

## Overall Flow

```mermaid
flowchart LR
  A[Doc request] --> B{version?}
  B -- v2 --> C[branchForVersion -> 2.x]
  B -- v3 --> D[branchForVersion -> 3.x]
  C --> E[fetch from payloadcms/payload @ 2.x]
  D --> F[fetch from payloadcms/payload @ 3.x]
```

Previously the v3 arm resolved to `main`.