### PR TITLE
docs: proper GitHub Dark theme for code blocks

### DIFF
--- a/src/components/Code/index.module.scss
+++ b/src/components/Code/index.module.scss
@@ -79,59 +79,6 @@ $curve: cubic-bezier(0.165, 0.84, 0.44, 1);
   @include dark-custom-scrollbar;
 
   :global {
-    .token.comment,
-    .token.prolog,
-    .token.doctype,
-    .token.cdata,
-    .token.punctuation {
-      color: var(--color-base-500);
-    }
-
-    .token.plain,
-    .token.atrule,
-    .token.attr-value,
-    .token.keyword {
-      color: var(--color-success-250);
-    }
-
-    .token.tag,
-    .token.boolean,
-    .token.number,
-    .token.constant,
-    .token.symbol,
-    .token.deleted {
-      color: var(--color-error-500);
-    }
-
-    .token.attr-name,
-    .token.char,
-    .token.builtin,
-    .token.inserted {
-      color: var(--color-base-100);
-    }
-
-    .token.operator,
-    .token.entity,
-    .token.url,
-    .language-css .token.string,
-    .style .token.string {
-      color: var(--color-base-500);
-    }
-
-    .token.selector,
-    .token-property,
-    .token.function {
-      color: var(--color-success-500);
-    }
-
-    .token.regex,
-    .token.important,
-    .token.variable,
-    .token.string,
-    .token.class-name {
-      color: var(--color-warning-500);
-    }
-
     .token.important,
     .token.bold {
       font-weight: bold;

--- a/src/components/Code/index.tsx
+++ b/src/components/Code/index.tsx
@@ -1,13 +1,46 @@
 'use client'
 
 import CodeBlip from '@components/CodeBlip/index'
-import { Highlight } from 'prism-react-renderer'
+import { Highlight, Prism } from 'prism-react-renderer'
 import React, { useCallback } from 'react'
 
 import type { Props } from './types'
 
 import classes from './index.module.scss'
 import { theme } from './theme'
+
+// Assignment must run before the `require` calls so the language components can
+// attach themselves to the global Prism instance.
+;(typeof global !== 'undefined' ? global : window).Prism = Prism
+require('prismjs/components/prism-bash')
+// css-extras must load before prism-scss so scss inherits its color/unit patterns.
+require('prismjs/components/prism-css-extras')
+require('prismjs/components/prism-scss')
+require('prismjs/components/prism-docker')
+require('prismjs/components/prism-http')
+
+// The bundled TypeScript grammar deletes `literal-property` (so unquoted object
+// keys go untokenized) but keeps `function-variable` (so a key whose value is a
+// function gets aliased to `function`). The result is that `slug:` and `handler:`
+// in the same object render with different token classes. Reverse that here.
+const literalProperty = {
+  'literal-property': {
+    alias: 'property',
+    lookbehind: true,
+    pattern: new RegExp(
+      '((?:^|[,{])[ \\t]*)(?!\\s)[_$a-zA-Z\\xA0-\\uFFFF](?:(?!\\s)[$\\w\\xA0-\\uFFFF])*(?=\\s*:)',
+      'm',
+    ),
+  },
+}
+delete (Prism.languages.typescript as any)['function-variable']
+delete (Prism.languages.tsx as any)['function-variable']
+Prism.languages.insertBefore('typescript', 'operator', literalProperty)
+Prism.languages.insertBefore('tsx', 'operator', literalProperty)
+
+// prism-scss replaces css's `variable` pattern with one that only matches `$foo`,
+// so CSS custom properties like `--theme-elevation-900` go untokenized. Broaden it.
+;(Prism.languages.scss as any).variable = /\$[-\w]+|--[\w-]+/
 
 let highlightStart = false
 const highlightClassName = classes.highlight
@@ -52,6 +85,7 @@ const Code: React.FC<Props> = (props) => {
     className,
     codeBlips,
     disableMinHeight,
+    language,
     parentClassName,
     showLineNumbers = true,
   } = props
@@ -83,9 +117,9 @@ const Code: React.FC<Props> = (props) => {
       data-theme={'dark'}
       translate="no"
     >
-      <Highlight code={children} language="tsx" theme={theme}>
-        {({ getLineProps, getTokenProps, style, tokens }) => (
-          <div className={classNames} style={style}>
+      <Highlight code={children} language={language ?? 'tsx'} theme={theme}>
+        {({ className: prismClassName, getLineProps, getTokenProps, style, tokens }) => (
+          <div className={`${classNames} ${prismClassName}`} style={style}>
             {tokens
               .map((line, i) => {
                 const lineProps = getLineProps({ className: classes.line, key: i, line })
@@ -109,8 +143,25 @@ const Code: React.FC<Props> = (props) => {
                       {showLineNumbers && <span className={classes.lineNumber}>{rowNumber}</span>}
                       <div className={classes.lineCodeWrapper}>
                         {line.map((token, index) => {
-                          const { key, ...rest } = getTokenProps({ key: index, token })
-                          return <span key={key as any} {...rest} />
+                          const { key, style: tokenStyle, ...rest } = getTokenProps({
+                            key: index,
+                            token,
+                          })
+                          // prism-react-renderer skips theme styles for plain tokens.
+                          // Force-color them where the grammar leaves intended content
+                          // un-tokenized: shell args (`payload jobs:run`) and YAML
+                          // unquoted scalars (`node:24-alpine`, `mongo`, etc.).
+                          const needsPlainColor =
+                            (language === 'bash' ||
+                              language === 'sh' ||
+                              language === 'yaml' ||
+                              language === 'yml') &&
+                            token.types.length === 1 &&
+                            token.types[0] === 'plain'
+                          const finalStyle = needsPlainColor
+                            ? { ...tokenStyle, color: '#79c0ff' }
+                            : tokenStyle
+                          return <span key={key as any} {...rest} style={finalStyle} />
                         })}
                         {codeBlip ? <CodeBlip.Button blip={codeBlip} index={blipCounter} /> : null}
                       </div>

--- a/src/components/Code/theme.ts
+++ b/src/components/Code/theme.ts
@@ -1,120 +1,103 @@
 import type { PrismTheme } from 'prism-react-renderer'
 
+// Faithful GitHub Dark (default) palette. Hex values from @primer/primitives'
+// dark scale; TextMate scope → Prism token mappings derived from
+// primer/github-vscode-theme/src/theme.js.
 export const theme: PrismTheme = {
   plain: {
-    color: '#d1d5da',
+    color: '#e6edf3',
   },
   styles: [
     {
-      style: {
-        color: '#8b949e',
-      },
-      types: ['comment'],
+      style: { color: '#8b949e' },
+      types: ['comment', 'prolog', 'cdata'],
     },
     {
-      style: {
-        color: '#ff7b72',
-      },
-      types: ['keyword', 'atrule.rule'],
+      style: { color: '#ff7b72' },
+      types: ['keyword', 'storage', 'atrule', 'important', 'rule'],
     },
     {
-      style: {
-        color: '#d2a8ff',
-      },
-      types: ['function'],
+      style: { color: '#a5d6ff' },
+      types: ['string', 'template-string', 'attr-value', 'regex', 'char'],
     },
     {
-      style: {
-        color: '#79d8a9',
-      },
+      style: { color: '#79c0ff' },
       types: [
-        'property',
-        'key',
-        'tag:not(.punctuation):not(.attr-name):not(.attr-value):not(.script)',
-        'selector',
-      ],
-    },
-    {
-      style: {
-        color: '#8cc4ff',
-      },
-      types: ['string', 'template-string', 'attr-value', 'hexcode.color'],
-    },
-    {
-      style: {
-        color: '#61afef',
-      },
-      types: [
+        'constant',
         'number',
         'boolean',
-        'keyword.nil',
         'null',
-        'doctype',
-        'attr-name',
-        'selector.class',
-        'selector.pseudo-class',
-        'selector.combinator',
+        'symbol',
+        'builtin',
         'property',
-        'atrule.keyword',
-        'operator',
-        'property-access',
+        'literal-property',
+        'attr-name',
+        'doctype',
+        'url',
+        'color',
+        'hexcode',
+        'unit',
       ],
     },
     {
-      style: {
-        color: '#e5c07b',
-      },
-      types: ['variable', 'class-name', 'maybe-class-name'],
+      style: { color: '#d2a8ff' },
+      // `selector` here covers Prism's single selector token type — in GitHub Dark
+      // top-level SCSS class selectors render purple; Prism doesn't distinguish
+      // primary from nested, so all selectors land here.
+      types: ['function', 'function-variable', 'selector'],
+    },
+    {
+      style: { color: '#7ee787' },
+      types: ['tag'],
+    },
+    {
+      style: { color: '#ffa657' },
+      types: ['variable', 'parameter', 'entity', 'class-name', 'maybe-class-name'],
+    },
+    // In GitHub Dark, shell args/flags/strings render as one blue mass. The matching
+    // override for `plain` tokens (bare identifiers like `payload jobs:run`) lives in
+    // the render code — prism-react-renderer hard-skips the theme for `plain`.
+    {
+      languages: ['bash', 'sh'],
+      style: { color: '#79c0ff' },
+      types: ['variable', 'parameter', 'string', 'template-string'],
+    },
+    // JS/TS object literal keys should render plain — CSS properties (also `property`
+    // token) keep their blue via the general rule above since this is per-language.
+    {
+      languages: ['js', 'jsx', 'ts', 'tsx'],
+      style: { color: '#e6edf3' },
+      types: ['property', 'literal-property'],
+    },
+    // GraphQL: just the keywords (query/mutation/etc) stay colored. Field names,
+    // types, enum constants, and input types all render plain.
+    {
+      languages: ['graphql'],
+      style: { color: '#e6edf3' },
+      types: ['property', 'attr-name', 'property-query', 'class-name', 'atom-input', 'constant'],
+    },
+    // YAML: green keys, blue values, gray comments. Nothing else. `key` carries an
+    // `atrule` alias that the general red rule otherwise wins via — include it here
+    // so the per-language override wins for both classes on the token.
+    {
+      languages: ['yaml', 'yml'],
+      style: { color: '#7ee787' },
+      types: ['key', 'atrule'],
+    },
+    {
+      languages: ['yaml', 'yml'],
+      style: { color: '#79c0ff' },
+      types: [
+        'scalar',
+        'string',
+        'number',
+        'boolean',
+        'null',
+        'datetime',
+        'tag',
+        'directive',
+        'important',
+      ],
     },
   ],
 }
-
-// export const theme: PrismTheme = {
-//   plain: {
-//     color: 'var(--color-base-500)',
-//   },
-//   styles: [
-//     {
-//       types: ['comment', 'prolog', 'doctype', 'cdata', 'punctuation'],
-//       style: {
-//         color: 'var(--color-base-500)',
-//       },
-//     },
-//     {
-//       types: ['plain', 'atrule', 'attr-value', 'keyword'],
-//       style: {
-//         color: 'var(--color-success-250)',
-//       },
-//     },
-//     {
-//       types: ['tag', 'boolean', 'number', 'constant', 'symbol', 'deleted', 'imports'],
-//       style: {
-//         color: 'var(--color-error-500)',
-//       },
-//     },
-//     {
-//       types: ['attr-name', 'char', 'builtin', 'inserted'],
-//       style: {
-//         color: 'var(--color-base-100)',
-//       },
-//     },
-//     {
-//       types: ['operator', 'entity', 'url', 'string'],
-//       style: {
-//         color: 'var(--color-base-500)',
-//       },
-//     },
-//     {
-//       types: ['selector', 'property', 'function'],
-//       style: {
-//         color: 'var(--color-success-500)',
-//       },
-//     },
-//     {
-//       types: ['regex', 'important', 'variable', 'string', 'class-name', 'parameter'],
-//       style: {
-//         color: 'var(--color-warning-500)',
-//       },
-//     },
-//   ],
-// }

--- a/src/components/Code/types.ts
+++ b/src/components/Code/types.ts
@@ -11,6 +11,7 @@ export interface Props {
   className?: string
   codeBlips?: CodeBlips
   disableMinHeight?: boolean
+  language?: string
   parentClassName?: string
   showLineNumbers?: boolean
   title?: string

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -54,13 +54,13 @@ import React, { useCallback, useMemo, useState } from 'react'
 
 import type { AllowedElements } from '../SpotlightAnimation/types'
 
-import { type AddHeading, type Heading, type IContext, RichTextContext } from './context'
 import { Arrow } from './Arrow'
 import { BulletList } from './BulletList'
+import { type AddHeading, type Heading, type IContext, RichTextContext } from './context'
 import { Heading as HeadingComponent } from './Heading'
-import { Pill } from './Pill'
 import { LightDarkImage } from './LightDarkImage/index'
 import { PayloadMediaBlock } from './PayloadMedia'
+import { Pill } from './Pill'
 import { ResourceBlock as Resource } from './ResourceBlock'
 import { RestExamples } from './RestExamples'
 import { CustomTableJSXConverters } from './Table/index'
@@ -119,7 +119,12 @@ export const jsxConverters: (args: { toc?: boolean }) => JSXConvertersFunction<N
         Code: ({ node }) => {
           const codeString: string = node.fields.code ?? ''
           return (
-            <Code children={codeString?.trim()} disableMinHeight parentClassName={'lexical-code'} />
+            <Code
+              children={codeString?.trim()}
+              disableMinHeight
+              language={node.fields.language ?? undefined}
+              parentClassName={'lexical-code'}
+            />
           )
         },
         commandLine: ({ node }) => {


### PR DESCRIPTION
The Code component ignored the MDX fence language and ran every block through Prism's TSX tokenizer, which produced incorrect highlighting for any non-TS language. This change honors the stored `language` field end-to-end and rebuilds the theme against the @primer/primitives dark palette used by GitHub and the official VS Code GitHub Dark theme.

- thread the fence language through RichText → Code → prism-react-renderer
- replace the hand-tuned palette with true GitHub Dark hex values
- register Prism components: bash, scss, dockerfile, http, css-extras
- delete the parallel :global CSS theme in index.module.scss that was competing with the JS theme

## Examples

### Current CSS Block

<img width="833" height="327" alt="current-css-color-theme" src="https://github.com/user-attachments/assets/2651f5b5-2d4d-4127-91ac-75acbdf98a25" />

### Updated CSS Block

<img width="842" height="333" alt="updated-css-color-theme" src="https://github.com/user-attachments/assets/2dbe8c0b-174f-4217-be2b-d494568fbf39" />

### Current plaintext Block

<img width="839" height="476" alt="current-plaintext-color-theme" src="https://github.com/user-attachments/assets/665c03b5-6840-4bc3-8b7c-5f76943b977d" />

### Updated plaintext Block

<img width="831" height="467" alt="updated-plaintext-color-theme" src="https://github.com/user-attachments/assets/8990d49b-4a07-446d-9857-bc1c9468bd5d" />

### Current bash Block

<img width="820" height="219" alt="current-bash-color-theme" src="https://github.com/user-attachments/assets/4055365d-13ac-4113-b063-3dbaf64e9127" />

### Updated bash Block

<img width="840" height="220" alt="updated-bash-color-theme" src="https://github.com/user-attachments/assets/136c3461-a5da-464c-9676-a643829844c5" />

### Current YML Block

<img width="844" height="1062" alt="Screenshot 2026-06-02 at 2 26 32 PM" src="https://github.com/user-attachments/assets/86fb6f1c-dc00-4879-bfe6-7b0c63e447bc" />

### Updated YML Block
<img width="840" height="1070" alt="Screenshot 2026-06-02 at 2 26 48 PM" src="https://github.com/user-attachments/assets/2b1f27e6-d60d-4446-9622-4bfa425ef388" />