### PR TITLE
fix: preserve docs markdown line merging

### DIFF
--- a/src/collections/Docs/mdxToLexical.ts
+++ b/src/collections/Docs/mdxToLexical.ts
@@ -91,10 +91,13 @@ export function mdxToLexical({
     headlessEditor.update(
       () => {
         try {
-          $convertFromMarkdownString(mdx, [
-            UploadBlockMarkdownTransformer,
-            ...editorConfig.features.markdownTransformers,
-          ])
+          $convertFromMarkdownString(
+            mdx,
+            [UploadBlockMarkdownTransformer, ...editorConfig.features.markdownTransformers],
+            undefined,
+            false,
+            true,
+          )
         } catch (e) {
           console.error('Error parsing markdown', mdx)
           throw e


### PR DESCRIPTION
## Summary

1. Preserve previous docs MDX import behavior by passing `shouldMergeAdjacentLines = true` when converting MDX to Lexical.
2. This pairs with https://github.com/payloadcms/payload/pull/17064, which removes Payload's vendored `@lexical/markdown` fork and uses upstream Lexical markdown behavior.

## Test plan

1. Verified the importer file has no linter diagnostics.
2. Ran the roundtrip docs comparison from the local website checkout against the Payload docs.