### PR TITLE
fix: ensure content fallback in RichTextWithTOC for server-rendered HTML

### DIFF
--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -273,13 +273,15 @@ export const RichTextWithTOC: React.FC<Props> = ({ className, content: _content 
 
   const initialData = useMemo(() => ({ content: _content }) as Doc, [_content])
 
-  const {
-    data: { content },
-  } = useLivePreview<Doc>({
+  const { data } = useLivePreview<Doc>({
     depth: 2,
     initialData,
     serverURL: process.env.NEXT_PUBLIC_CMS_URL as string,
   })
+
+  // Fall back to the server-provided content so the doc body is present in the
+  // server-rendered HTML.
+  const content = data?.content ?? _content
 
   const addHeading: AddHeading = useCallback(
     (anchor, heading, type) => {


### PR DESCRIPTION
Fixes an issue where docs content was not available to the Algolia crawler, causing a loss of records and preventing us from having up to date documentation.

The issue comes from `useLivePreview` returns empty `content` during server rendering. This change makes it so that we fall back to the server-provided content so the doc body is present in the server-rendered HTML.