### PR TITLE
feat: adds tabbed code blocks for docs

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -32,6 +32,7 @@ import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c08
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
+import { codeTabsConverterClient as codeTabsConverterClient_6f1ac6e923df77f95b7732b8e2ea677b } from '@root/collections/Docs/blocks/codeTabs/converterClient'
 import { SaveButtonClient as SaveButtonClient_259d8f559cb11a4167281a913f510f62 } from '@root/collections/Docs/SaveButton'
 import { BranchButton as BranchButton_a056620e50cdeec34262a2e060477165 } from '@root/collections/Docs/BranchButton'
 import { Label as Label_087cde4d1fde05040831b5843a5fb654 } from '@root/fields/addToDocs/Label'
@@ -42,8 +43,13 @@ import { default as default_26726ff2b18133c6c2dab451ecac5a3e } from '@root/compo
 import { default as default_3ee709fabb34ea93648b8fdb9ee7323a } from '@root/components/AfterNavActions'
 import { default as default_b8668daa8bdf783ddeca7def5b7c2324 } from '@root/components/BeforeDashboard'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
-import { CollectionCards as CollectionCards_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
+import { default as default_e229387af5e21bff3f46f156f2efb24b } from '@zubricks/plugin-google-analytics/widgets/AnalyticsMetricsWrapper'
+import { default as default_83d03cf47a3921584b5f60548f0203e7 } from '@zubricks/plugin-google-analytics/widgets/AnalyticsTopPagesWrapper'
+import { default as default_71e34bedb368f93cc101b4ff0d11d405 } from '@zubricks/plugin-google-analytics/widgets/ActiveUsers'
+import { default as default_aca03ed201d19f133d32b301aa2f10b4 } from '@zubricks/plugin-google-analytics/widgets/ChannelGroupsWrapper'
+import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
+/** @type import('payload').ImportMap */
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
@@ -79,6 +85,7 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
+  "@root/collections/Docs/blocks/codeTabs/converterClient#codeTabsConverterClient": codeTabsConverterClient_6f1ac6e923df77f95b7732b8e2ea677b,
   "@root/collections/Docs/SaveButton#SaveButtonClient": SaveButtonClient_259d8f559cb11a4167281a913f510f62,
   "@root/collections/Docs/BranchButton#BranchButton": BranchButton_a056620e50cdeec34262a2e060477165,
   "@root/fields/addToDocs/Label#Label": Label_087cde4d1fde05040831b5843a5fb654,
@@ -89,5 +96,9 @@ export const importMap = {
   "@root/components/AfterNavActions#default": default_3ee709fabb34ea93648b8fdb9ee7323a,
   "@root/components/BeforeDashboard#default": default_b8668daa8bdf783ddeca7def5b7c2324,
   "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
-  "@payloadcms/ui/rsc#CollectionCards": CollectionCards_ab83ff7e88da8d3530831f296ec4756a
+  "@zubricks/plugin-google-analytics/widgets/AnalyticsMetricsWrapper#default": default_e229387af5e21bff3f46f156f2efb24b,
+  "@zubricks/plugin-google-analytics/widgets/AnalyticsTopPagesWrapper#default": default_83d03cf47a3921584b5f60548f0203e7,
+  "@zubricks/plugin-google-analytics/widgets/ActiveUsers#default": default_71e34bedb368f93cc101b4ff0d11d405,
+  "@zubricks/plugin-google-analytics/widgets/ChannelGroupsWrapper#default": default_aca03ed201d19f133d32b301aa2f10b4,
+  "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/collections/Docs/blocks/codeTabs/converter.ts
+++ b/src/collections/Docs/blocks/codeTabs/converter.ts
@@ -1,0 +1,105 @@
+import type { BlockJSX } from 'payload'
+
+import { languages } from '../shared'
+
+type CodeTab = {
+  code: string
+  label: string
+  language: string
+}
+
+const codeFenceStart = /^\s*(`{3,}|~{3,})([\w-]+)?\s+label=("(?:\\.|[^"\\])*")\s*$/
+
+const getCodeFence = (code: string): string => {
+  let longestFence = 2
+
+  for (const line of code.split('\n')) {
+    const match = line.match(/^\s*(`+)/)
+    if (match) {
+      longestFence = Math.max(longestFence, match[1].length)
+    }
+  }
+
+  return '`'.repeat(longestFence + 1)
+}
+
+export const codeTabsToMarkdown = (tabs: CodeTab[]): string =>
+  tabs
+    .map(({ code, label, language }) => {
+      const fence = getCodeFence(code)
+      return `${fence}${language || 'plaintext'} label=${JSON.stringify(label)}\n${code}\n${fence}`
+    })
+    .join('\n\n')
+
+export const markdownToCodeTabs = (markdown: string): CodeTab[] | false => {
+  const lines = markdown.replace(/^\n/, '').replace(/\n$/, '').split('\n')
+  const tabs: CodeTab[] = []
+  let lineIndex = 0
+
+  while (lineIndex < lines.length) {
+    if (!lines[lineIndex].trim()) {
+      lineIndex++
+      continue
+    }
+
+    const startMatch = lines[lineIndex].match(codeFenceStart)
+    if (!startMatch) {
+      return false
+    }
+
+    const fence = startMatch[1]
+    const language = startMatch[2] || 'plaintext'
+    let label: string
+
+    try {
+      label = JSON.parse(startMatch[3]) as string
+    } catch {
+      return false
+    }
+    const codeLines: string[] = []
+    const closingFence = new RegExp(`^\\s*${fence[0]}{${fence.length},}\\s*$`)
+
+    lineIndex++
+    while (lineIndex < lines.length && !closingFence.test(lines[lineIndex])) {
+      codeLines.push(lines[lineIndex])
+      lineIndex++
+    }
+
+    if (lineIndex === lines.length) {
+      return false
+    }
+
+    if (!languages[language as keyof typeof languages]) {
+      console.error(`Invalid language "${language}" in CodeTabs block`)
+    }
+
+    if (!label) {
+      return false
+    }
+
+    tabs.push({
+      code: codeLines.join('\n'),
+      label,
+      language,
+    })
+    lineIndex++
+  }
+
+  return tabs.length >= 2 ? tabs : false
+}
+
+export const codeTabsConverter: BlockJSX = {
+  doNotTrimChildren: true,
+  export: ({ fields }) => ({
+    children: codeTabsToMarkdown(fields.tabs ?? []),
+  }),
+  import: ({ children }) => {
+    const tabs = markdownToCodeTabs(children)
+
+    if (!tabs) {
+      return false
+    }
+
+    return { tabs }
+  },
+}

--- a/src/collections/Docs/blocks/codeTabs/converterClient.ts
+++ b/src/collections/Docs/blocks/codeTabs/converterClient.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export { codeTabsConverter as codeTabsConverterClient } from './converter'

--- a/src/collections/Docs/blocks/codeTabs/index.ts
+++ b/src/collections/Docs/blocks/codeTabs/index.ts
@@ -1,0 +1,51 @@
+import type { Block } from 'payload'
+
+import { languages } from '../shared'
+import { codeTabsConverter } from './converter'
+
+export const CodeTabsBlock: Block = {
+  slug: 'CodeTabs',
+  admin: {
+    jsx: '@root/collections/Docs/blocks/codeTabs/converterClient#codeTabsConverterClient',
+  },
+  fields: [
+    {
+      name: 'tabs',
+      type: 'array',
+      fields: [
+        {
+          name: 'label',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'language',
+          type: 'select',
+          defaultValue: 'ts',
+          options: Object.entries(languages).map(([key, value]) => ({
+            label: value,
+            value: key,
+          })),
+          required: true,
+        },
+        {
+          name: 'code',
+          type: 'code',
+          required: true,
+        },
+      ],
+      labels: {
+        plural: 'Tabs',
+        singular: 'Tab',
+      },
+      minRows: 2,
+      required: true,
+    },
+  ],
+  interfaceName: 'CodeTabsBlock',
+  labels: {
+    plural: 'Code Tabs',
+    singular: 'Code Tabs',
+  },
+  jsx: codeTabsConverter,
+}

--- a/src/collections/Docs/index.ts
+++ b/src/collections/Docs/index.ts
@@ -44,6 +44,7 @@ export const contentLexicalEditorFeatures: FeatureProviderServer[] = [
   BlocksFeature({
     blocks: [
       'Code',
+      'CodeTabs',
       'Banner',
       'YouTube',
       'LightDarkImage',

--- a/src/components/RichText/CodeTabs/index.module.scss
+++ b/src/components/RichText/CodeTabs/index.module.scss
@@ -1,0 +1,90 @@
+.root {
+  margin-bottom: 2rem;
+  overflow: hidden;
+  border: 1px solid var(--color-base-700);
+  border-radius: 4px;
+  background: var(--color-base-850);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--color-base-700);
+  background: var(--color-base-900);
+}
+
+.list {
+  display: flex;
+  flex: 1;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 0.75rem;
+}
+
+.trigger {
+  appearance: none;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-base-300);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--color-base-850);
+    color: var(--color-base-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -3px;
+  }
+
+  &[data-state='active'] {
+    border-color: var(--color-base-700);
+    background: var(--color-base-800);
+    color: var(--color-base-100);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 30%);
+  }
+}
+
+.copyButton {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-right: 0.75rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-base-300);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--color-base-700);
+    background: var(--color-base-800);
+    color: var(--color-base-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -3px;
+  }
+}
+
+.content:focus-visible {
+  outline: 2px solid var(--theme-text);
+  outline-offset: -2px;
+}
+
+.code {
+  margin: 0;
+  background: var(--color-base-850);
+}

--- a/src/components/RichText/CodeTabs/index.tsx
+++ b/src/components/RichText/CodeTabs/index.tsx
@@ -10,59 +10,64 @@ import React from 'react'
 
 import classes from './index.module.scss'
 
+const preferenceEvent = 'payload:code-tab-change'
+const preferenceKey = 'payload-docs-code-tab'
+
 export const CodeTabs: React.FC<CodeTabsBlockType> = ({ tabs }) => {
-  const tabValues = React.useMemo(
-    () => tabs?.map((tab, index) => tab.id || `code-tab-${index}`) ?? [],
-    [tabs],
-  )
-  const [activeTab, setActiveTab] = React.useState(tabValues[0] ?? '')
+  const [activeTab, setActiveTab] = React.useState(0)
   const [isCopied, setIsCopied] = React.useState(false)
-  const copyTimeout = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   React.useEffect(() => {
-    if (!tabValues.includes(activeTab)) {
-      setActiveTab(tabValues[0] ?? '')
-    }
-  }, [activeTab, tabValues])
+    const selectTab = (label: null | string) => {
+      const index = tabs?.findIndex((tab) => tab.label === label) ?? -1
 
-  React.useEffect(
-    () => () => {
-      clearTimeout(copyTimeout.current)
-    },
-    [],
-  )
+      if (index >= 0) {
+        setActiveTab(index)
+        setIsCopied(false)
+      }
+    }
+
+    const handlePreferenceChange = (event: Event) => {
+      selectTab((event as CustomEvent<string>).detail)
+    }
+
+    selectTab(localStorage.getItem(preferenceKey))
+    window.addEventListener(preferenceEvent, handlePreferenceChange)
+
+    return () => window.removeEventListener(preferenceEvent, handlePreferenceChange)
+  }, [tabs])
 
   if (!tabs?.length) {
     return null
   }
 
-  const activeTabIndex = tabValues.indexOf(activeTab)
-  const activeCode = tabs[activeTabIndex]?.code ?? ''
-
-  const copyActiveCode = async () => {
-    await navigator.clipboard.writeText(activeCode)
+  const copyActiveCode = () => {
+    void navigator.clipboard.writeText(tabs[activeTab]?.code ?? '')
     setIsCopied(true)
-    clearTimeout(copyTimeout.current)
-    copyTimeout.current = setTimeout(() => setIsCopied(false), 1500)
+    setTimeout(() => setIsCopied(false), 1500)
   }
 
   return (
     <Tabs.Root
       className={classes.root}
       onValueChange={(value) => {
-        setActiveTab(value)
+        const index = Number(value)
+        const label = tabs[index]?.label
+
+        setActiveTab(index)
         setIsCopied(false)
+
+        if (label) {
+          localStorage.setItem(preferenceKey, label)
+          window.dispatchEvent(new CustomEvent(preferenceEvent, { detail: label }))
+        }
       }}
-      value={activeTab}
+      value={String(activeTab)}
     >
       <div className={classes.bar}>
         <Tabs.List aria-label="Code examples" className={classes.list}>
           {tabs.map((tab, index) => (
-            <Tabs.Trigger
-              className={classes.trigger}
-              key={tabValues[index]}
-              value={tabValues[index]}
-            >
+            <Tabs.Trigger className={classes.trigger} key={tab.id ?? index} value={String(index)}>
               {tab.label}
             </Tabs.Trigger>
           ))}
@@ -78,7 +83,7 @@ export const CodeTabs: React.FC<CodeTabsBlockType> = ({ tabs }) => {
         </button>
       </div>
       {tabs.map((tab, index) => (
-        <Tabs.Content className={classes.content} key={tabValues[index]} value={tabValues[index]}>
+        <Tabs.Content className={classes.content} key={tab.id ?? index} value={String(index)}>
           <Code
             children={tab.code ?? ''}
             disableMinHeight

--- a/src/components/RichText/CodeTabs/index.tsx
+++ b/src/components/RichText/CodeTabs/index.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import type { CodeTabsBlock as CodeTabsBlockType } from '@root/payload-types'
+
+import Code from '@components/Code'
+import { CheckIcon } from '@icons/CheckIcon'
+import { CopyIcon } from '@icons/CopyIcon'
+import * as Tabs from '@radix-ui/react-tabs'
+import React from 'react'
+
+import classes from './index.module.scss'
+
+export const CodeTabs: React.FC<CodeTabsBlockType> = ({ tabs }) => {
+  const tabValues = React.useMemo(
+    () => tabs?.map((tab, index) => tab.id || `code-tab-${index}`) ?? [],
+    [tabs],
+  )
+  const [activeTab, setActiveTab] = React.useState(tabValues[0] ?? '')
+  const [isCopied, setIsCopied] = React.useState(false)
+  const copyTimeout = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  React.useEffect(() => {
+    if (!tabValues.includes(activeTab)) {
+      setActiveTab(tabValues[0] ?? '')
+    }
+  }, [activeTab, tabValues])
+
+  React.useEffect(
+    () => () => {
+      clearTimeout(copyTimeout.current)
+    },
+    [],
+  )
+
+  if (!tabs?.length) {
+    return null
+  }
+
+  const activeTabIndex = tabValues.indexOf(activeTab)
+  const activeCode = tabs[activeTabIndex]?.code ?? ''
+
+  const copyActiveCode = async () => {
+    await navigator.clipboard.writeText(activeCode)
+    setIsCopied(true)
+    clearTimeout(copyTimeout.current)
+    copyTimeout.current = setTimeout(() => setIsCopied(false), 1500)
+  }
+
+  return (
+    <Tabs.Root
+      className={classes.root}
+      onValueChange={(value) => {
+        setActiveTab(value)
+        setIsCopied(false)
+      }}
+      value={activeTab}
+    >
+      <div className={classes.bar}>
+        <Tabs.List aria-label="Code examples" className={classes.list}>
+          {tabs.map((tab, index) => (
+            <Tabs.Trigger
+              className={classes.trigger}
+              key={tabValues[index]}
+              value={tabValues[index]}
+            >
+              {tab.label}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        <button
+          aria-label={isCopied ? 'Copied code' : 'Copy code to clipboard'}
+          className={classes.copyButton}
+          onClick={copyActiveCode}
+          title={isCopied ? 'Copied' : 'Copy code'}
+          type="button"
+        >
+          {isCopied ? <CheckIcon size="large" /> : <CopyIcon size="large" />}
+        </button>
+      </div>
+      {tabs.map((tab, index) => (
+        <Tabs.Content className={classes.content} key={tabValues[index]} value={tabValues[index]}>
+          <Code
+            children={tab.code ?? ''}
+            disableMinHeight
+            language={tab.language ?? undefined}
+            parentClassName={classes.code}
+          />
+        </Tabs.Content>
+      ))}
+    </Tabs.Root>
+  )
+}

--- a/src/components/RichText/index.tsx
+++ b/src/components/RichText/index.tsx
@@ -13,6 +13,7 @@ import type {
   CardBlock,
   CardGroupBlock,
   CodeBlock,
+  CodeTabsBlock,
   CommandLineBlock,
   Doc,
   DownloadBlockType,
@@ -60,6 +61,7 @@ import { Arrow } from './Arrow'
 import { BulletList } from './BulletList'
 import { Card } from './Card/index'
 import { CardGroup } from './CardGroup/index'
+import { CodeTabs } from './CodeTabs'
 import { type AddHeading, type Heading, type IContext, RichTextContext } from './context'
 import { Heading as HeadingComponent } from './Heading'
 import { LightDarkImage } from './LightDarkImage/index'
@@ -87,6 +89,7 @@ export type NodeTypes =
       | CardBlock
       | CardGroupBlock
       | CodeBlock
+      | CodeTabsBlock
       | CommandLineBlock
       | DownloadBlockType
       | LightDarkImageBlock
@@ -147,6 +150,9 @@ export const jsxConverters: (args: { toc?: boolean }) => JSXConvertersFunction<N
               parentClassName={'lexical-code'}
             />
           )
+        },
+        CodeTabs: ({ node }) => {
+          return <CodeTabs {...node.fields} />
         },
         commandLine: ({ node }) => {
           const { command } = node.fields

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -118,6 +118,7 @@ export interface Config {
     templateCards: TemplateCardsBlock;
     Banner: BannerBlock;
     Code: CodeBlock;
+    CodeTabs: CodeTabsBlock;
     code: Code;
   };
   collections: {
@@ -3339,6 +3340,40 @@ export interface CodeBlock {
   id?: string | null;
   blockName?: string | null;
   blockType: 'Code';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "CodeTabsBlock".
+ */
+export interface CodeTabsBlock {
+  tabs: {
+    label: string;
+    language:
+      | 'bash'
+      | 'css'
+      | 'dockerfile'
+      | 'env'
+      | 'graphql'
+      | 'html'
+      | 'http'
+      | 'js'
+      | 'json'
+      | 'jsx'
+      | 'plaintext'
+      | 'scss'
+      | 'sh'
+      | 'text'
+      | 'ts'
+      | 'tsx'
+      | 'vue'
+      | 'yaml'
+      | 'yml';
+    code: string;
+    id?: string | null;
+  }[];
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'CodeTabs';
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -62,6 +62,7 @@ import { BulletListBlock } from './collections/Docs/blocks/bulletList'
 import { CardBlock } from './collections/Docs/blocks/card'
 import { CardGroupBlock } from './collections/Docs/blocks/cardGroup'
 import { CodeBlock } from './collections/Docs/blocks/code'
+import { CodeTabsBlock } from './collections/Docs/blocks/codeTabs'
 import { LightDarkImageBlock } from './collections/Docs/blocks/lightDarkImage'
 import { PayloadMediaBlock } from './collections/Docs/blocks/payloadMedia'
 import { PillBlock } from './collections/Docs/blocks/pill'
@@ -288,6 +289,7 @@ export default buildConfig({
     },
     BannerBlock,
     CodeBlock,
+    CodeTabsBlock,
     Code,
   ],
   collections: [


### PR DESCRIPTION
- adds a new block for docs / richtext in the case where we need to surface nextjs code snippets / tanstack
- tab preference applies to multiple instances of tabbed code blocks on a topic and persisted with localStorage
- adds copy to clipboard feature

I explored extending the existing code block, but given docs authors will need to restructure the MDX either way (as a single code fence does not contain the additional tab labels and alternative snippets) making `Code` optionally tabbed would not eliminate that work—it would only move the complexity into a widely used block and its converter.

Usage in Docs:

`<CodeTabs>`
```tsx label="Next.js"
'use server'

import { login } from '@payloadcms/next/auth'
import config from '@payload-config'

export function loginAction(email: string, password: string) {
  return login({
    collection: 'users',
    config,
    email,
    password,
  })
}
```

```tsx label="TanStack Start"
import { createServerFn } from '@tanstack/react-start'

const loginAction = createServerFn({ method: 'POST' })
  .validator((data: { email: string; password: string }) => data)
  .handler(async ({ data }) => {
    const [{ login }, { default: config }] = await Promise.all([
      import('@payloadcms/tanstack-start/server'),
      import('@payload-config'),
    ])

    return login({
      collection: 'users',
      config,
      email: data.email,
      password: data.password,
    })
  })
```
`</CodeTabs>`

https://github.com/user-attachments/assets/62510692-7794-4faf-ad4b-70035c5ca46b

